### PR TITLE
Added Unit Tests for form field based HTTP Method Override

### DIFF
--- a/src/Microsoft.AspNet.HttpOverrides/HttpMethodOverrideMiddleware.cs
+++ b/src/Microsoft.AspNet.HttpOverrides/HttpMethodOverrideMiddleware.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.HttpOverrides
 
         public async Task Invoke(HttpContext context)
         {
-            if (string.Equals(context.Request.Method,"POST", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(context.Request.Method, "POST", StringComparison.OrdinalIgnoreCase))
             {
                 if (_options.FormFieldName != null)
                 {

--- a/test/Microsoft.AspNet.HttpOverrides.Tests/HttpMethodOverrideMiddlewareTest.cs
+++ b/test/Microsoft.AspNet.HttpOverrides.Tests/HttpMethodOverrideMiddlewareTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
@@ -75,6 +76,99 @@ namespace Microsoft.AspNet.HttpOverrides
             var server = new TestServer(builder);
 
             var req = new HttpRequestMessage(HttpMethod.Get, "");
+            await server.CreateClient().SendAsync(req);
+            Assert.True(assertsExecuted);
+        }
+
+
+        [Fact]
+        public async Task FormFieldAvailableChangesRequestMethod()
+        {
+            var assertsExecuted = false;
+            var builder = new WebApplicationBuilder()
+                .Configure(app =>
+                {
+                    app.UseHttpMethodOverride(new HttpMethodOverrideOptions()
+                    {
+                        FormFieldName = "_METHOD"
+                    });
+                    app.Run(context =>
+                    {
+                        Assert.Equal("DELETE", context.Request.Method);
+                        assertsExecuted = true;
+                        return Task.FromResult(0);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var req = new HttpRequestMessage(HttpMethod.Post, "");
+            req.Content = new FormUrlEncodedContent(new Dictionary<string, string>()
+            {
+                { "_METHOD", "DELETE" }
+            });
+
+
+            await server.CreateClient().SendAsync(req);
+            Assert.True(assertsExecuted);
+        }
+
+        [Fact]
+        public async Task FormFieldUnavailableDoesNotChangeRequestMethod()
+        {
+            var assertsExecuted = false;
+            var builder = new WebApplicationBuilder()
+                .Configure(app =>
+                {
+                    app.UseHttpMethodOverride(new HttpMethodOverrideOptions()
+                    {
+                        FormFieldName = "_METHOD"
+                    });
+                    app.Run(context =>
+                    {
+                        Assert.Equal("POST", context.Request.Method);
+                        assertsExecuted = true;
+                        return Task.FromResult(0);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var req = new HttpRequestMessage(HttpMethod.Post, "");
+            req.Content = new FormUrlEncodedContent(new Dictionary<string, string>()
+            {
+            });
+
+
+            await server.CreateClient().SendAsync(req);
+            Assert.True(assertsExecuted);
+        }
+
+        [Fact]
+        public async Task FormFieldEmptyDoesNotChangeRequestMethod()
+        {
+            var assertsExecuted = false;
+            var builder = new WebApplicationBuilder()
+                .Configure(app =>
+                {
+                    app.UseHttpMethodOverride(new HttpMethodOverrideOptions()
+                    {
+                        FormFieldName = "_METHOD"
+                    });
+                    app.Run(context =>
+                    {
+                        Assert.Equal("POST", context.Request.Method);
+                        assertsExecuted = true;
+                        return Task.FromResult(0);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var req = new HttpRequestMessage(HttpMethod.Post, "");
+            req.Content = new FormUrlEncodedContent(new Dictionary<string, string>()
+            {
+                { "_METHOD", "" }
+            });
+
+
             await server.CreateClient().SendAsync(req);
             Assert.True(assertsExecuted);
         }


### PR DESCRIPTION
I was just thinking about prototyping the issue I filed, when I came across that there are some unit tests missing in the field of HTTP Method Override based on form data.