### PR TITLE
Fix for regex coherence error. Small clean up.

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/UrlRewriteOptionsAddRulesExtensions.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/UrlRewriteOptionsAddRulesExtensions.cs
@@ -3,12 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text.RegularExpressions;
-using Microsoft.AspNetCore.Rewrite.ModRewrite;
 using Microsoft.AspNetCore.Rewrite.RuleAbstraction;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Rewrite
 {

--- a/src/Microsoft.AspNetCore.Rewrite/project.json
+++ b/src/Microsoft.AspNetCore.Rewrite/project.json
@@ -26,11 +26,19 @@
     "Microsoft.Extensions.Configuration.Abstractions": "1.1.0-*",
     "Microsoft.Extensions.FileProviders.Abstractions": "1.1.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.1.0-*",
-    "Microsoft.Extensions.Options": "1.1.0-*",
-    "System.Text.RegularExpressions": "4.1.0-*"
+    "Microsoft.Extensions.Options": "1.1.0-*"
   },
   "frameworks": {
-    "net451": {},
-    "netstandard1.3": {}
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Xml.Linq": ""
+      }
+    },
+    "netstandard1.3": {
+      "dependencies": {
+        "System.Text.RegularExpressions": "4.1.0-*",
+        "System.Xml.XDocument": "4.0.11-*"
+      }
+    }
   }
 }


### PR DESCRIPTION
@pranavkm 
Coherence failed on my regex dependency. Error I got was:
`Microsoft.AspNetCore.Rewrite.1.1.0-alpha1-21716 depends on System.Text.RegularExpressions v[4.0.0, ) (.NETFramework,Version=v4.5.1) when the latest build is v4.1.0.`
The project.json file suggested I go up to 4.1.0, but I got this failure in coherence. 
