### PR TITLE
Fix to tokenizing mod_rewrite rules

### DIFF
--- a/test/Microsoft.AspNetCore.Rewrite.Tests/ModRewrite/RewriteTokenizerTest.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/ModRewrite/RewriteTokenizerTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.ModRewrite
 
             var expected = new List<string>();
             expected.Add("RewriteCond");
-            expected.Add(@"%{HTTPS}\ what");
+            expected.Add(@"%{HTTPS} what");
             expected.Add("!-f");
             Assert.Equal(tokens, expected);
         }
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.ModRewrite
             var expected = new List<string>();
             expected.Add(@"RewriteCond");
             expected.Add(@"%{HTTPS}");
-            expected.Add(@"\ what");
+            expected.Add(@" what");
             expected.Add(@"!-f");
             Assert.Equal(tokens, expected);
         }
@@ -59,7 +59,21 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.ModRewrite
             var expected = new List<string>();
             expected.Add(@"RewriteCond");
             expected.Add(@"%{HTTPS}");
-            expected.Add(@"\ what");
+            expected.Add(@" what");
+            expected.Add(@"!-f");
+            Assert.Equal(expected, tokens);
+        }
+
+        [Fact]
+        public void Tokenize_CheckQuotesAreProperlyRemovedFromString()
+        {
+            var testString = "RewriteCond \"%{HTTPS}\" \"\\ what\" \"!-f\"    ";
+            var tokens = new Tokenizer().Tokenize(testString);
+
+            var expected = new List<string>();
+            expected.Add(@"RewriteCond");
+            expected.Add(@"%{HTTPS}");
+            expected.Add(@" what");
             expected.Add(@"!-f");
             Assert.Equal(expected, tokens);
         }
@@ -67,9 +81,15 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.ModRewrite
         [Fact]
         public void Tokenize_AssertFormatExceptionWhenEscapeCharacterIsAtEndOfString()
         {
-
             var ex = Assert.Throws<FormatException>(() => new Tokenizer().Tokenize("\\"));
             Assert.Equal(@"Invalid escaper character in string: \", ex.Message);
+        }
+
+        [Fact]
+        public void Tokenize_AssertFormatExceptionWhenUnevenNumberOfQuotes()
+        {
+            var ex = Assert.Throws<FormatException>(() => new Tokenizer().Tokenize("\""));
+            Assert.Equal("Mismatched number of quotes: \"", ex.Message);
         }
     }
 }


### PR DESCRIPTION
Escaped characters prior didn't remove the escape character \, which was incorrect. Also, sections can be enclosed by quotation marks ", which are trimmed from rules now.
Notes:

- Currently using .Trim() and .Replace() to do this.
- Characters can be escaped in string enclosed by quotation marks. Hence no matter what we remove the \ characters,