### PR TITLE
Removes startsWith in favor of array indexing, More null/empty checks

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/Internal/ModRewrite/FlagParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/ModRewrite/FlagParser.cs
@@ -63,7 +63,8 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ModRewrite
             }
 
             // Check that flags are contained within []
-            if (!(flagString.StartsWith("[") && flagString.EndsWith("]")))
+            // Guaranteed to have a length of at least 1 here, so this will never throw for indexing.
+            if (!(flagString[0] == '[' && flagString[flagString.Length - 1] == ']'))
             {
                 throw new FormatException("Flags should start and end with square brackets: [flags]");
             }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/ModRewrite/RuleRegexParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/ModRewrite/RuleRegexParser.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ModRewrite
             {
                 throw new FormatException("Regex expression is null");
             }
-            if (regex.StartsWith("!"))
+            if (regex[0] == '!')
             {
                 return new ParsedModRewriteInput { Invert = true, Operand = regex.Substring(1) };
             }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/UrlActions/RedirectAction.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/UrlActions/RedirectAction.cs
@@ -53,7 +53,14 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.UrlActions
                 pattern = Uri.EscapeDataString(pattern);
             }
 
-            if (pattern.IndexOf("://", StringComparison.Ordinal) == -1 && !pattern.StartsWith("/"))
+            if (string.IsNullOrEmpty(pattern))
+            {
+                response.Headers[HeaderNames.Location] = "/";
+                return;
+            }
+
+
+            if (pattern.IndexOf("://", StringComparison.Ordinal) == -1 && pattern[0] != '/')
             {
                 pattern = '/' + pattern;
             }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/UrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/UrlRewrite/UrlRewriteFileParser.cs
@@ -165,7 +165,6 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.UrlRewrite
             }
 
             var parsedPatternString = condition.Attribute(RewriteTags.Pattern)?.Value;
-
             try
             {
                 var input = _inputParser.ParseInputString(parsedInputString);
@@ -197,9 +196,19 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.UrlRewrite
                 redirectType = RedirectType.Permanent;
             }
 
+            string url = string.Empty;
+            if (urlAction.Attribute(RewriteTags.Url) != null)
+            {
+                url = urlAction.Attribute(RewriteTags.Url).Value;
+                if (string.IsNullOrEmpty(url))
+                {
+                    ThrowUrlFormatException(urlAction, "Url attribute cannot contain an empty string");
+                }
+            }
+
             try
             {
-                var input = _inputParser.ParseInputString(urlAction.Attribute(RewriteTags.Url)?.Value);
+                var input = _inputParser.ParseInputString(url);
                 builder.AddUrlAction(input, actionType, appendQuery, stopProcessing, (int)redirectType);
             }
             catch (FormatException formatException)

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/UrlRewrite/UrlRewriteRuleBuilder.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/UrlRewrite/UrlRewriteRuleBuilder.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.UrlRewrite
                         {
                             case MatchType.Pattern:
                                 {
-                                    if (pattern == null)
+                                    if (string.IsNullOrEmpty(pattern))
                                     {
                                         throw new FormatException("Match does not have an associated pattern attribute in condition");
                                     }

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/CodeRules/MiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/CodeRules/MiddlewareTests.cs
@@ -67,5 +67,40 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.CodeRules
 
             Assert.Equal(response.Headers.Location.OriginalString, "https://example.com/");
         }
+
+
+        [Fact]
+        public async Task CheckIfEmptyStringRedirectCorrectly()
+        {
+            var options = new RewriteOptions().AddRedirect("(.*)", "$1", statusCode: 301);
+            var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.UseRewriter(options);
+            });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync("");
+            Assert.Equal(response.Headers.Location.OriginalString, "/");
+        }
+
+        [Fact]
+        public async Task CheckIfEmptyStringRewriteCorrectly()
+        {
+            var options = new RewriteOptions().AddRewrite("(.*)", "$1");
+            var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.UseRewriter(options);
+                app.Run(context => context.Response.WriteAsync(
+                        context.Request.Path +
+                        context.Request.QueryString));
+            });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetStringAsync("");
+
+            Assert.Equal(response, "/");
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/UrlRewrite/FormatExceptionHandlingTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/UrlRewrite/FormatExceptionHandlingTests.cs
@@ -91,6 +91,16 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
     </rules>
 </rewrite>", 
             "Could not parse the UrlRewrite file. Message: 'Match does not have an associated pattern attribute in condition'. Line number '6': '18'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Rewrite to article.aspx"">
+            <match url = ""(.*)"" />
+            <action type=""Rewrite"" url ="""" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'Url attribute cannot contain an empty string'. Line number '5': '14'.")]
         public void ThrowFormatExceptionWithCorrectMessage(string input, string expected)
         {
             // Arrange, Act, Assert


### PR DESCRIPTION
The perf on startsWith was generally slow and I could be using indexing into the string for better perf.
Before
![before](https://cloud.githubusercontent.com/assets/8302101/18147308/e7ae28e8-6f88-11e6-869d-2bf83605c3e3.PNG)
After
![after](https://cloud.githubusercontent.com/assets/8302101/18147310/e9255cf0-6f88-11e6-9eb2-f90f451131db.PNG)

This example was done on RedirectRule, but applies to all rules and actions being applied.

Also there was a case where if the url was an empty string, the rule would not throw on parse, which it should (after investigating IIS).