### PR TITLE
Remove rewrite rule API with default assumptions about skip remaining rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ project.lock.json
 .testPublish/
 .idea/
 .vscode/
-
+*.nuget.props
+*.nuget.targets

--- a/samples/RewriteSample/Startup.cs
+++ b/samples/RewriteSample/Startup.cs
@@ -15,7 +15,7 @@ namespace RewriteSample
         {
             var options = new RewriteOptions()
                 .AddRedirect("(.*)/$", "$1")
-                .AddRewrite(@"app/(\d+)", "app?id=$1")
+                .AddRewrite(@"app/(\d+)", "app?id=$1", skipRemainingRules: false)
                 .AddRedirectToHttps(302, 5001)
                 .AddIISUrlRewrite(env.ContentRootFileProvider, "UrlRewrite.xml")
                 .AddApacheModRewrite(env.ContentRootFileProvider, "Rewrite.txt");

--- a/src/Microsoft.AspNetCore.Rewrite/RewriteOptionsExtensions.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/RewriteOptionsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Rewrite
         }
 
         /// <summary>
-        /// Rewrites the path if the regex matches the HttpContext's PathString
+        /// Add a rule that rewrites the path if the regex matches the HttpContext's PathString and skips remaining rules.
         /// </summary>
         /// <param name="options">The <see cref="RewriteOptions"/>.</param>
         /// <param name="regex">The regex string to compare with.</param>
@@ -44,11 +44,11 @@ namespace Microsoft.AspNetCore.Rewrite
         /// <returns>The Rewrite options.</returns>
         public static RewriteOptions AddRewrite(this RewriteOptions options, string regex, string replacement)
         {
-            return AddRewrite(options, regex, replacement, skipRemainingRules: false);
+            return AddRewrite(options, regex, replacement, skipRemainingRules: true);
         }
 
         /// <summary>
-        /// Rewrites the path if the regex matches the HttpContext's PathString
+        /// Adds a rule that rewrites the path if the regex matches the HttpContext's PathString.
         /// </summary>
         /// <param name="options">The <see cref="RewriteOptions"/>.</param>
         /// <param name="regex">The regex string to compare with.</param>

--- a/src/Microsoft.AspNetCore.Rewrite/RewriteOptionsExtensions.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/RewriteOptionsExtensions.cs
@@ -36,18 +36,6 @@ namespace Microsoft.AspNetCore.Rewrite
         }
 
         /// <summary>
-        /// Add a rule that rewrites the path if the regex matches the HttpContext's PathString and skips remaining rules.
-        /// </summary>
-        /// <param name="options">The <see cref="RewriteOptions"/>.</param>
-        /// <param name="regex">The regex string to compare with.</param>
-        /// <param name="replacement">If the regex matches, what to replace HttpContext with.</param>
-        /// <returns>The Rewrite options.</returns>
-        public static RewriteOptions AddRewrite(this RewriteOptions options, string regex, string replacement)
-        {
-            return AddRewrite(options, regex, replacement, skipRemainingRules: true);
-        }
-
-        /// <summary>
         /// Adds a rule that rewrites the path if the regex matches the HttpContext's PathString.
         /// </summary>
         /// <param name="options">The <see cref="RewriteOptions"/>.</param>

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/MiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/MiddlewareTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.CodeRules
         [Fact]
         public async Task CheckRewritePath()
         {
-            var options = new RewriteOptions().AddRewrite("(.*)", "http://example.com/$1");
+            var options = new RewriteOptions().AddRewrite("(.*)", "http://example.com/$1", skipRemainingRules: false);
             var builder = new WebHostBuilder()
                 .Configure(app =>
                 {
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.CodeRules
         [Fact]
         public async Task CheckIfEmptyStringRewriteCorrectly()
         {
-            var options = new RewriteOptions().AddRewrite("(.*)", "$1");
+            var options = new RewriteOptions().AddRewrite("(.*)", "$1", skipRemainingRules: false);
             var builder = new WebHostBuilder()
             .Configure(app =>
             {


### PR DESCRIPTION
Changes an important, common use-case. When defining rewrite rules explicitly, the `.Add(string regex, string replacement)` API should default to setting `skipRemainingRules = true`.

Consider the following code and graph:
```c#
var option = new RewriteOption();
// where N is the x-axis on the graph
for(var tenant = 1; tenant <= N; tenant++) 
{
   option.Add($"app/{tenant}/(.*)", "/common/$1?tenantid=" + tenant);
}
```
![rewrite_middleware_perf_chart](https://cloud.githubusercontent.com/assets/2696087/18725378/f1ed47a4-7ff4-11e6-9afc-321d2fca7f61.png)

When skipRemainingRules=false, we get the the performance shown on the orange line.
This is a perf hit of -75% raw throughput for *all requests*, not just the rewritten ones.
 
With skipRemainingRules=true (proposed default), we get the the performance shown on the yellow line (only ~7% perf hit).

The overload `.Add(string regex, string replacement, bool skipRemainingRules)` is still available for the less-common case of wanting chained rewrite rules.


cc @Tratcher @mikaelm12 