### PR TITLE
Make flush work

### DIFF
--- a/samples/ResponseCompressionSample/CustomCompressionProvider.cs
+++ b/samples/ResponseCompressionSample/CustomCompressionProvider.cs
@@ -7,6 +7,8 @@ namespace ResponseCompressionSample
     {
         public string EncodingName => "custom";
 
+        public bool SupportsFlush => true;
+
         public Stream CreateStream(Stream outputStream)
         {
             // Create a custom compression stream wrapper here

--- a/samples/ResponseCompressionSample/Startup.cs
+++ b/samples/ResponseCompressionSample/Startup.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace ResponseCompressionSample
 {
@@ -22,6 +26,23 @@ namespace ResponseCompressionSample
         {
             app.UseResponseCompression();
 
+            app.Map("/trickle", trickleApp =>
+            {
+                trickleApp.Run(async context =>
+                {
+                    context.Response.ContentType = "text/plain";
+                    // Disables compression on net451 because that GZipStream does not implement Flush.
+                    context.Features.Get<IHttpBufferingFeature>()?.DisableResponseBuffering();
+
+                    for (int i = 0; i < 100; i++)
+                    {
+                        await context.Response.WriteAsync("a");
+                        await context.Response.Body.FlushAsync();
+                        await Task.Delay(TimeSpan.FromSeconds(1));
+                    }
+                });
+            });
+
             app.Run(async context =>
             {
                 context.Response.ContentType = "text/plain";
@@ -32,7 +53,14 @@ namespace ResponseCompressionSample
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
-                .UseKestrel()
+                .UseKestrel(options =>
+                {
+                    options.UseConnectionLogging();
+                })
+                .ConfigureLogging(factory =>
+                {
+                    factory.AddConsole(LogLevel.Debug);
+                })
                 .UseStartup<Startup>()
                 .Build();
 

--- a/samples/ResponseCompressionSample/project.json
+++ b/samples/ResponseCompressionSample/project.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "Microsoft.AspNetCore.ResponseCompression": "0.1.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-*"
+    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-*",
+    "Microsoft.Extensions.Logging.Console": "1.1.0-*"
   },
   "buildOptions": {
     "emitEntryPoint": true

--- a/src/Microsoft.AspNetCore.ResponseCompression/GzipCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/GzipCompressionProvider.cs
@@ -11,15 +11,23 @@ namespace Microsoft.AspNetCore.ResponseCompression
     /// </summary>
     public class GzipCompressionProvider : ICompressionProvider
     {
-        /// <summary>
-        /// Initialize a new <see cref="GzipCompressionProvider"/>.
-        /// </summary>
-        public GzipCompressionProvider()
-        {
-        }
-
         /// <inheritdoc />
         public string EncodingName => "gzip";
+
+        /// <inheritdoc />
+        public bool SupportsFlush
+        {
+            get
+            {
+#if NET451
+                return false;
+#elif NETSTANDARD1_3
+                return true;
+#else
+                // Not implemented, compiler break
+#endif
+            }
+        }
 
         /// <summary>
         /// What level of compression to use for the stream.

--- a/src/Microsoft.AspNetCore.ResponseCompression/ICompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ICompressionProvider.cs
@@ -16,6 +16,11 @@ namespace Microsoft.AspNetCore.ResponseCompression
         string EncodingName { get; }
 
         /// <summary>
+        /// Indicates if the given provider supports Flush and FlushAsync. If not, compression may be disabled in some scenarios.
+        /// </summary>
+        bool SupportsFlush { get; }
+
+        /// <summary>
         /// Create a new compression stream.
         /// </summary>
         /// <param name="outputStream">The stream where the compressed data have to be written.</param>

--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
@@ -108,6 +108,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
                 mimeType = mimeType.Trim();
             }
 
+            // TODO PERF: StringSegments?
             return _mimeTypes.Contains(mimeType);
         }
     }


### PR DESCRIPTION
#108 @davidfowl @JunTaoLuo 
GZipStream supports flush on core but not net451. Optionally disable compression if flush is not supported.