### PR TITLE
Move compression providers back to options

### DIFF
--- a/samples/ResponseCompressionSample/Startup.cs
+++ b/samples/ResponseCompressionSample/Startup.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -18,9 +18,13 @@ namespace ResponseCompressionSample
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<ICompressionProvider, GzipCompressionProvider>();
-            services.AddSingleton<ICompressionProvider, CustomCompressionProvider>();
-            services.AddResponseCompression("text/plain", "text/html");
+            services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.Fastest);
+            services.AddResponseCompression(options =>
+            {
+                options.Providers.Add<GzipCompressionProvider>();
+                options.Providers.Add<CustomCompressionProvider>();
+                options.MimeTypes = new[] { "text/plain", "text/html" };
+            });
         }
 
         public void Configure(IApplicationBuilder app)
@@ -63,10 +67,7 @@ namespace ResponseCompressionSample
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
-                .UseKestrel(options =>
-                {
-                    options.UseConnectionLogging();
-                })
+                .UseKestrel()
                 // .UseWebListener()
                 .ConfigureLogging(factory =>
                 {

--- a/src/Microsoft.AspNetCore.ResponseCompression/CompressionProviderCollection.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/CompressionProviderCollection.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+#if NETSTANDARD1_3
+using System.Reflection;
+#endif
+
+namespace Microsoft.AspNetCore.ResponseCompression
+{
+    /// <summary>
+    /// A Collection of ICompressionProvider's that also allows them to be instantiated from an <see cref="IServiceProvider" />.
+    /// </summary>
+    public class CompressionProviderCollection : Collection<ICompressionProvider>
+    {
+        /// <summary>
+        /// Adds a type representing an <see cref="ICompressionProvider"/>.
+        /// </summary>
+        /// <remarks>
+        /// Provider instances will be created using an <see cref="IServiceProvider" />.
+        /// </remarks>
+        public void Add<TCompressionProvider>() where TCompressionProvider : ICompressionProvider
+        {
+            Add(typeof(TCompressionProvider));
+        }
+
+        /// <summary>
+        /// Adds a type representing an <see cref="ICompressionProvider"/>.
+        /// </summary>
+        /// <param name="providerType">Type representing an <see cref="ICompressionProvider"/>.</param>
+        /// <remarks>
+        /// Provider instances will be created using an <see cref="IServiceProvider" />.
+        /// </remarks>
+        public void Add(Type providerType)
+        {
+            if (providerType == null)
+            {
+                throw new ArgumentNullException(nameof(providerType));
+            }
+
+            if (!typeof(ICompressionProvider).IsAssignableFrom(providerType))
+            {
+                throw new ArgumentException($"The provider must implement {nameof(ICompressionProvider)}", nameof(providerType));
+            }
+
+            var factory = new CompressionProviderFactory(providerType);
+            Add(factory);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.ResponseCompression/CompressionProviderFactory.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/CompressionProviderFactory.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.ResponseCompression
+{
+    /// <summary>
+    /// This is a placeholder for the CompressionProviderCollection that allows creating the given type via
+    /// an <see cref="IServiceProvider" />.
+    /// </summary>
+    internal class CompressionProviderFactory : ICompressionProvider
+    {
+        internal CompressionProviderFactory(Type providerType)
+        {
+            ProviderType = providerType;
+        }
+
+        internal Type ProviderType { get; }
+
+        internal ICompressionProvider CreateInstance(IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            return (ICompressionProvider)ActivatorUtilities.CreateInstance(serviceProvider, ProviderType, Type.EmptyTypes);
+        }
+
+        string ICompressionProvider.EncodingName
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        bool ICompressionProvider.SupportsFlush
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        Stream ICompressionProvider.CreateStream(Stream outputStream)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.ResponseCompression/GzipCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/GzipCompressionProvider.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.IO.Compression;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.ResponseCompression
 {
@@ -11,6 +13,22 @@ namespace Microsoft.AspNetCore.ResponseCompression
     /// </summary>
     public class GzipCompressionProvider : ICompressionProvider
     {
+        /// <summary>
+        /// Creates a new instance of GzipCompressionProvider with options.
+        /// </summary>
+        /// <param name="options"></param>
+        public GzipCompressionProvider(IOptions<GzipCompressionProviderOptions> options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            Options = options.Value;
+        }
+
+        private GzipCompressionProviderOptions Options { get; }
+
         /// <inheritdoc />
         public string EncodingName => "gzip";
 
@@ -29,15 +47,10 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
         }
 
-        /// <summary>
-        /// What level of compression to use for the stream.
-        /// </summary>
-        public CompressionLevel Level { get; set; } = CompressionLevel.Fastest;
-
         /// <inheritdoc />
         public Stream CreateStream(Stream outputStream)
         {
-            return new GZipStream(outputStream, Level, leaveOpen: true);
+            return new GZipStream(outputStream, Options.Level, leaveOpen: true);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.ResponseCompression/GzipCompressionProviderOptions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/GzipCompressionProviderOptions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO.Compression;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.ResponseCompression
+{
+    /// <summary>
+    /// Options for the GzipCompressionProvider
+    /// </summary>
+    public class GzipCompressionProviderOptions : IOptions<GzipCompressionProviderOptions>
+    {
+        /// <summary>
+        /// What level of compression to use for the stream. The default is Fastest.
+        /// </summary>
+        public CompressionLevel Level { get; set; } = CompressionLevel.Fastest;
+
+        /// <inheritdoc />
+        GzipCompressionProviderOptions IOptions<GzipCompressionProviderOptions>.Value => this;
+    }
+}

--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionOptions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionOptions.cs
@@ -20,5 +20,10 @@ namespace Microsoft.AspNetCore.ResponseCompression
         /// Enable compression on HTTPS connections may expose security problems.
         /// </summary>
         public bool EnableForHttps { get; set; } = false;
+
+        /// <summary>
+        /// The ICompressionProviders to use for responses.
+        /// </summary>
+        public CompressionProviderCollection Providers { get; } = new CompressionProviderCollection();
     }
 }


### PR DESCRIPTION
https://github.com/aspnet/BasicMiddleware/issues/108#issuecomment-253042371 @DamianEdwards @Eilon @rynowak 
Moved ICompressionProvider registration from DI to options. Emulates MVC's FilterCollection.