### PR TITLE
Changed url rewrite sample regex to be more specific

### DIFF
--- a/samples/RewriteSample/UrlRewrite.xml
+++ b/samples/RewriteSample/UrlRewrite.xml
@@ -1,7 +1,7 @@
 ﻿<rewrite>
   <rules>
     <rule name="Rewrite 20 to 10" stopProcessing="true">
-      <match url="(.*)" />
+      <match url="^app$" />
       <conditions>
         <add input="{QUERY_STRING}" pattern="id=20" />
       </conditions>


### PR DESCRIPTION
The intended result of the IIS Rewrite sample rule was to redirect requests that had queries of `app?id=20` to `app?id=10`. While this did work, the matching criteria was too general. It would rewrite, for example, `example?id=20` to `app?id=10`

@Tratcher @natemcmaster @muratg 