### PR TITLE
Fixed exception messages for server variable parsing

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/ServerVariables.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/ServerVariables.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
                 case "TIME":
                     return new DateTimeSegment(serverVariable);
                 case "API_VERSION":
-                    throw new NotSupportedException();
+                    throw new NotSupportedException("Rules using the API_VERSION server variable are not supported");
                 case "HTTPS":
                     return new IsHttpsModSegment();
                 case "HTTP2":

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/ServerVariables.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/ServerVariables.cs
@@ -16,12 +16,12 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
         /// <summary>
         /// Translates mod_rewrite server variables strings to an enum of different server variables.
         /// </summary>
-        /// <param name="variable">The server variable string.</param>
+        /// <param name="serverVariable">The server variable string.</param>
         /// <param name="context">The Parser context</param>
         /// <returns>The appropriate enum if the server variable exists, else ServerVariable.None</returns>
-        public static PatternSegment FindServerVariable(string variable, ParserContext context)
+        public static PatternSegment FindServerVariable(string serverVariable, ParserContext context)
         {
-            switch (variable)
+            switch (serverVariable)
             {
                 case "HTTP_ACCEPT":
                     return new HeaderSegment(HeaderNames.Accept);
@@ -84,21 +84,21 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
                 case "SERVER_SOFTWARE":
                     throw new NotSupportedException("Rules using the SERVER_SOFTWARE server variable are not supported");
                 case "TIME_YEAR":
-                    return new DateTimeSegment(variable);
+                    return new DateTimeSegment(serverVariable);
                 case "TIME_MON":
-                    return new DateTimeSegment(variable);
+                    return new DateTimeSegment(serverVariable);
                 case "TIME_DAY":
-                    return new DateTimeSegment(variable);
+                    return new DateTimeSegment(serverVariable);
                 case "TIME_HOUR":
-                    return new DateTimeSegment(variable);
+                    return new DateTimeSegment(serverVariable);
                 case "TIME_MIN":
-                    return new DateTimeSegment(variable);
+                    return new DateTimeSegment(serverVariable);
                 case "TIME_SEC":
-                    return new DateTimeSegment(variable);
+                    return new DateTimeSegment(serverVariable);
                 case "TIME_WDAY":
-                    return new DateTimeSegment(variable);
+                    return new DateTimeSegment(serverVariable);
                 case "TIME":
-                    return new DateTimeSegment(variable);
+                    return new DateTimeSegment(serverVariable);
                 case "API_VERSION":
                     throw new NotSupportedException();
                 case "HTTPS":
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
                 case "THE_REQUEST":
                     throw new NotSupportedException("Rules using the THE_REQUEST server variable are not supported");
                 default:
-                    throw new FormatException(Resources.FormatError_InputParserUnrecognizedParameter(variable, context.Index));
+                    throw new FormatException(Resources.FormatError_InputParserUnrecognizedParameter(serverVariable, context.Index));
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/InputParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/InputParser.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                 {
                     // This is just a server variable, so we do a lookup and verify the server variable exists.
                     parameter = context.Capture();
-                    results.Add(ServerVariables.FindServerVariable(parameter));
+                    results.Add(ServerVariables.FindServerVariable(parameter, context));
                     return;
                 }
                 else if (context.Current == Colon)

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/ServerVariables.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/ServerVariables.cs
@@ -9,15 +9,15 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 {
     public static class ServerVariables
     {
-        public static PatternSegment FindServerVariable(string serverVariable)
+        public static PatternSegment FindServerVariable(string serverVariable, ParserContext context)
         {
             switch (serverVariable)
             {
                 // TODO Add all server variables here.
                 case "ALL_RAW":
-                    throw new NotSupportedException("Rules using the AUTH_TYPE server variable are not supported");
+                    throw new NotSupportedException("Rules using the ALL_RAW server variable are not supported");
                 case "APP_POOL_ID":
-                    throw new NotSupportedException("Rules using the AUTH_TYPE server variable are not supported");
+                    throw new NotSupportedException("Rules using the APP_POOL_ID server variable are not supported");
                 case "CONTENT_LENGTH":
                     return new HeaderSegment(HeaderNames.ContentLength);
                 case "CONTENT_TYPE":
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                 case "LOCAL_ADDR":
                     return new LocalAddressSegment();
                 case "HTTP_PROXY_CONNECTION":
-                    throw new NotSupportedException("Rules using the AUTH_TYPE server variable are not supported");
+                    throw new NotSupportedException("Rules using the HTTP_PROXY_CONNECTION server variable are not supported");
                 case "QUERY_STRING":
                     return new QueryStringSegment();
                 case "REMOTE_ADDR":
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                 case "REQUEST_URI":
                     return new UrlSegment();
                 default:
-                    throw new FormatException("Unrecognized server variable");
+                    throw new FormatException(Resources.FormatError_InputParserUnrecognizedParameter(serverVariable, context.Index));
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/ServerVariableTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/ServerVariableTests.cs
@@ -27,7 +27,8 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         public void CheckServerVariableParsingAndApplication(string variable, string expected)
         {
             // Arrange and Act
-            var serverVar = ServerVariables.FindServerVariable(variable);
+            var testParserContext = new ParserContext("test");
+            var serverVar = ServerVariables.FindServerVariable(variable, testParserContext);
             var lookup = serverVar.Evaluate(CreateTestHttpContext(), CreateTestRuleMatch(), CreateTestCondMatch());
             // Assert
             Assert.Equal(expected, lookup);


### PR DESCRIPTION
Main thing here is that some of the exception messages for the server variable parsing was incorrect as pointed out in https://github.com/aspnet/BasicMiddleware/issues/143. I also did some refactoring to make the server variable parsing for IIS Url rewrite and Apache mod rewrite a little more similar.

Not urgent, just thought I'd open the pr.

@BrennanConroy @Tratcher @natemcmaster  @muratg 