### PR TITLE
Fix enum parsing

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/MatchType.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/MatchType.cs
@@ -5,8 +5,8 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 {
     public enum MatchType
     {
-        pattern,
-        isFile,
-        isDirectory
+        Pattern,
+        IsFile,
+        IsDirectory
     }
 }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/MatchType.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/MatchType.cs
@@ -5,7 +5,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 {
     public enum MatchType
     {
-        Pattern,
+        pattern,
         isFile,
         isDirectory
     }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/MatchType.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/MatchType.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
     public enum MatchType
     {
         Pattern,
-        IsFile,
-        IsDirectory
+        isFile,
+        isDirectory
     }
 }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/PatternSyntax.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/PatternSyntax.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
     public enum PatternSyntax
     {
         ECMAScript,
-        WildCard,
+        Wildcard,
         ExactMatch
     }
 }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/RewriteTags.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/RewriteTags.cs
@@ -5,29 +5,30 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 {
     public static class RewriteTags
     {
-        public const string Rewrite = "rewrite";
-        public const string GlobalRules = "globalRules";
-        public const string Rules = "rules";
-        public const string Rule = "rule";
         public const string Action = "action";
-        public const string Name = "name";
-        public const string Enabled = "enabled";
-        public const string PatternSyntax = "patternSyntax";
-        public const string StopProcessing = "stopProcessing";
-        public const string Match = "match";
-        public const string Conditions = "conditions";
-        public const string IgnoreCase = "ignoreCase";
-        public const string Negate = "negate";
-        public const string Url = "url";
-        public const string MatchType = "matchType";
         public const string Add = "add";
-        public const string TrackingAllCaptures = "trackingAllCaptures";
-        public const string MatchPattern = "matchPattern";
-        public const string Input = "input";
-        public const string Pattern = "pattern";
-        public const string Type = "type";
         public const string AppendQueryString = "appendQueryString";
+        public const string Conditions = "conditions";
+        public const string Enabled = "enabled";
+        public const string GlobalRules = "globalRules";
+        public const string IgnoreCase = "ignoreCase";
+        public const string Input = "input";
+        public const string LogicalGrouping = "logicalGrouping";
         public const string LogRewrittenUrl = "logRewrittenUrl";
+        public const string Match = "match";
+        public const string MatchPattern = "matchPattern";
+        public const string MatchType = "matchType";
+        public const string Name = "name";
+        public const string Negate = "negate";
+        public const string Pattern = "pattern";
+        public const string PatternSyntax = "patternSyntax";
+        public const string Rewrite = "rewrite";
         public const string RedirectType = "redirectType";
+        public const string Rule = "rule";
+        public const string Rules = "rules";
+        public const string StopProcessing = "stopProcessing";
+        public const string TrackingAllCaptures = "trackingAllCaptures";
+        public const string Type = "type";
+        public const string Url = "url";
     }
 }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             RedirectType redirectType;
-            if(urlAction.Attribute(RewriteTags.RedirectType) == null)
+            if (urlAction.Attribute(RewriteTags.RedirectType) == null)
             {
                 redirectType = RedirectType.Permanent;
             }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -77,9 +77,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             PatternSyntax patternSyntax;
-            if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax)?.Value, ignoreCase:true, result:out patternSyntax))
+            if (rule.Attribute(RewriteTags.PatternSyntax) == null)
             {
                 patternSyntax = PatternSyntax.ECMAScript;
+            }
+            else if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax).Value, ignoreCase: true, result:out patternSyntax))
+            {
+                ThrowParameterFormatException(rule, "The patternSyntax parameter was not recognized");
             }
 
             bool stopProcessing;
@@ -135,9 +139,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             LogicalGrouping grouping;
-            if (!Enum.TryParse(conditions.Attribute(RewriteTags.MatchType)?.Value, ignoreCase:true, result:out grouping))
+            if (conditions.Attribute(RewriteTags.LogicalGrouping) == null)
             {
                 grouping = LogicalGrouping.MatchAll;
+            }
+            else if (!Enum.TryParse(conditions.Attribute(RewriteTags.LogicalGrouping).Value, ignoreCase: true, result: out grouping))
+            {
+                ThrowParameterFormatException(conditions, "The logicalGrouping parameter was not recognized");
             }
 
             bool trackingAllCaptures;
@@ -169,9 +177,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             MatchType matchType;
-            if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType)?.Value, ignoreCase:true, result:out matchType))
+            if (condition.Attribute(RewriteTags.MatchType) == null)
             {
                 matchType = MatchType.Pattern;
+            }
+            else if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType).Value, ignoreCase: true, result: out matchType))
+            {
+                ThrowParameterFormatException(condition, "The matchType parameter wasn't recognized");
             }
 
             var parsedInputString = condition.Attribute(RewriteTags.Input)?.Value;
@@ -195,9 +207,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
         private void ParseUrlAction(XElement urlAction, UrlRewriteRuleBuilder builder, bool stopProcessing)
         {
             ActionType actionType;
-            if (!Enum.TryParse(urlAction.Attribute(RewriteTags.Type)?.Value, ignoreCase:true, result:out actionType))
+            if (urlAction.Attribute(RewriteTags.Type) == null)
             {
                 actionType = ActionType.None;
+            }
+            else if (!Enum.TryParse(urlAction.Attribute(RewriteTags.Type).Value, ignoreCase: true, result: out actionType))
+            {
+                ThrowParameterFormatException(urlAction, "The action type parameter was not recognized");
             }
 
             bool appendQuery;
@@ -211,12 +227,9 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             {
                 redirectType = RedirectType.Permanent;
             }
-            else
+            else if (!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType).Value, ignoreCase: true, result: out redirectType))
             {
-                if(!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType)?.Value, ignoreCase: true, result: out redirectType))
-                {
-                    ThrowParameterFormatException(urlAction, "The redirectType parameter was unrecognized");
-                }
+                ThrowParameterFormatException(urlAction, "The redirectType parameter was unrecognized");
             }
 
             string url = string.Empty;

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType).Value, ignoreCase: true, result: out matchType))
             {
-                ThrowParameterFormatException(condition, $"The {RewriteTags.MatchType} parameter '{condition.Attribute(RewriteTags.MatchType).Value}' wasn't recognized");
+                ThrowParameterFormatException(condition, $"The {RewriteTags.MatchType} parameter '{condition.Attribute(RewriteTags.MatchType).Value}' was not recognized");
             }
 
             var parsedInputString = condition.Attribute(RewriteTags.Input)?.Value;
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType).Value, ignoreCase: true, result: out redirectType))
             {
-                ThrowParameterFormatException(urlAction, $"The {RewriteTags.RedirectType} parameter '{urlAction.Attribute(RewriteTags.RedirectType).Value}' was unrecognized");
+                ThrowParameterFormatException(urlAction, $"The {RewriteTags.RedirectType} parameter '{urlAction.Attribute(RewriteTags.RedirectType).Value}' was not recognized");
             }
 
             string url = string.Empty;

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax).Value, ignoreCase: true, result: out patternSyntax))
             {
-                ThrowParameterFormatException(rule, $"The {RewriteTags.PatternSyntax} parameter: {rule.Attribute(RewriteTags.PatternSyntax).Value}, was not recognized");
+                ThrowParameterFormatException(rule, $"The {RewriteTags.PatternSyntax} parameter '{rule.Attribute(RewriteTags.PatternSyntax).Value}' was not recognized");
             }
 
             bool stopProcessing;
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(conditions.Attribute(RewriteTags.LogicalGrouping).Value, ignoreCase: true, result: out grouping))
             {
-                ThrowParameterFormatException(conditions, $"The {RewriteTags.LogicalGrouping} parameter: {conditions.Attribute(RewriteTags.LogicalGrouping).Value}, was not recognized");
+                ThrowParameterFormatException(conditions, $"The {RewriteTags.LogicalGrouping} parameter '{conditions.Attribute(RewriteTags.LogicalGrouping).Value}' was not recognized");
             }
 
             bool trackingAllCaptures;
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType).Value, ignoreCase: true, result: out matchType))
             {
-                ThrowParameterFormatException(condition, $"The {RewriteTags.MatchType} parameter: {condition.Attribute(RewriteTags.MatchType).Value}, wasn't recognized");
+                ThrowParameterFormatException(condition, $"The {RewriteTags.MatchType} parameter '{condition.Attribute(RewriteTags.MatchType).Value}' wasn't recognized");
             }
 
             var parsedInputString = condition.Attribute(RewriteTags.Input)?.Value;
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(urlAction.Attribute(RewriteTags.Type).Value, ignoreCase: true, result: out actionType))
             {
-                ThrowParameterFormatException(urlAction, $"The {RewriteTags.Type} parameter: {urlAction.Attribute(RewriteTags.Type).Value}, was not recognized");
+                ThrowParameterFormatException(urlAction, $"The {RewriteTags.Type} parameter '{urlAction.Attribute(RewriteTags.Type).Value}' was not recognized");
             }
 
             bool appendQuery;
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType).Value, ignoreCase: true, result: out redirectType))
             {
-                ThrowParameterFormatException(urlAction, $"The {RewriteTags.RedirectType} parameter: {urlAction.Attribute(RewriteTags.RedirectType).Value}, was unrecognized");
+                ThrowParameterFormatException(urlAction, $"The {RewriteTags.RedirectType} parameter '{urlAction.Attribute(RewriteTags.RedirectType).Value}' was unrecognized");
             }
 
             string url = string.Empty;

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             PatternSyntax patternSyntax;
-            if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax)?.Value, out patternSyntax))
+            if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax)?.Value, true, out patternSyntax))
             {
                 patternSyntax = PatternSyntax.ECMAScript;
             }
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             LogicalGrouping grouping;
-            if (!Enum.TryParse(conditions.Attribute(RewriteTags.MatchType)?.Value, out grouping))
+            if (!Enum.TryParse(conditions.Attribute(RewriteTags.MatchType)?.Value, true, out grouping))
             {
                 grouping = LogicalGrouping.MatchAll;
             }
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             MatchType matchType;
-            if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType)?.Value, out matchType))
+            if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType)?.Value, true, out matchType))
             {
                 matchType = MatchType.Pattern;
             }
@@ -195,7 +195,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
         private void ParseUrlAction(XElement urlAction, UrlRewriteRuleBuilder builder, bool stopProcessing)
         {
             ActionType actionType;
-            if (!Enum.TryParse(urlAction.Attribute(RewriteTags.Type)?.Value, out actionType))
+            if (!Enum.TryParse(urlAction.Attribute(RewriteTags.Type)?.Value, true, out actionType))
             {
                 actionType = ActionType.None;
             }
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             RedirectType redirectType;
-            if (!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType)?.Value, out redirectType))
+            if (!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType)?.Value, true, out redirectType))
             {
                 redirectType = RedirectType.Permanent;
             }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -81,9 +81,9 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             {
                 patternSyntax = PatternSyntax.ECMAScript;
             }
-            else if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax).Value, ignoreCase: true, result:out patternSyntax))
+            else if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax).Value, ignoreCase: true, result: out patternSyntax))
             {
-                ThrowParameterFormatException(rule, "The patternSyntax parameter was not recognized");
+                ThrowParameterFormatException(rule, $"The {RewriteTags.PatternSyntax} parameter: {rule.Attribute(RewriteTags.PatternSyntax).Value}, was not recognized");
             }
 
             bool stopProcessing;
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(conditions.Attribute(RewriteTags.LogicalGrouping).Value, ignoreCase: true, result: out grouping))
             {
-                ThrowParameterFormatException(conditions, "The logicalGrouping parameter was not recognized");
+                ThrowParameterFormatException(conditions, $"The {RewriteTags.LogicalGrouping} parameter: {conditions.Attribute(RewriteTags.LogicalGrouping).Value}, was not recognized");
             }
 
             bool trackingAllCaptures;
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType).Value, ignoreCase: true, result: out matchType))
             {
-                ThrowParameterFormatException(condition, "The matchType parameter wasn't recognized");
+                ThrowParameterFormatException(condition, $"The {RewriteTags.MatchType} parameter: {condition.Attribute(RewriteTags.MatchType).Value}, wasn't recognized");
             }
 
             var parsedInputString = condition.Attribute(RewriteTags.Input)?.Value;
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(urlAction.Attribute(RewriteTags.Type).Value, ignoreCase: true, result: out actionType))
             {
-                ThrowParameterFormatException(urlAction, "The action type parameter was not recognized");
+                ThrowParameterFormatException(urlAction, $"The {RewriteTags.Type} parameter: {urlAction.Attribute(RewriteTags.Type).Value}, was not recognized");
             }
 
             bool appendQuery;
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
             else if (!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType).Value, ignoreCase: true, result: out redirectType))
             {
-                ThrowParameterFormatException(urlAction, "The redirectType parameter was unrecognized");
+                ThrowParameterFormatException(urlAction, $"The {RewriteTags.RedirectType} parameter: {urlAction.Attribute(RewriteTags.RedirectType).Value}, was unrecognized");
             }
 
             string url = string.Empty;
@@ -255,22 +255,25 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 
         private static void ThrowUrlFormatException(XElement element, string message)
         {
-            var line = ((IXmlLineInfo)element).LineNumber;
-            var col = ((IXmlLineInfo)element).LinePosition;
+            var lineInfo = (IXmlLineInfo)element;
+            var line = lineInfo.LineNumber;
+            var col = lineInfo.LinePosition;
             throw new FormatException(Resources.FormatError_UrlRewriteParseError(message, line, col));
         }
 
         private static void ThrowUrlFormatException(XElement element, string message, Exception ex)
         {
-            var line = ((IXmlLineInfo)element).LineNumber;
-            var col = ((IXmlLineInfo)element).LinePosition;
+            var lineInfo = (IXmlLineInfo)element;
+            var line = lineInfo.LineNumber;
+            var col = lineInfo.LinePosition;
             throw new FormatException(Resources.FormatError_UrlRewriteParseError(message, line, col), ex);
         }
 
         private static void ThrowParameterFormatException(XElement element, string message)
         {
-            var line = ((IXmlLineInfo)element).LineNumber;
-            var col = ((IXmlLineInfo)element).LinePosition;
+            var lineInfo = (IXmlLineInfo)element;
+            var line = lineInfo.LineNumber;
+            var col = lineInfo.LinePosition;
             throw new FormatException(Resources.FormatError_UrlRewriteParseError(message, line, col));
         }
     }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             MatchType matchType;
             if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType)?.Value, true, out matchType))
             {
-                matchType = MatchType.Pattern;
+                matchType = MatchType.pattern;
             }
 
             var parsedInputString = condition.Attribute(RewriteTags.Input)?.Value;

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             PatternSyntax patternSyntax;
-            if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax)?.Value, true, out patternSyntax))
+            if (!Enum.TryParse(rule.Attribute(RewriteTags.PatternSyntax)?.Value, ignoreCase:true, result:out patternSyntax))
             {
                 patternSyntax = PatternSyntax.ECMAScript;
             }
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             bool ignoreCase;
             if (!bool.TryParse(match.Attribute(RewriteTags.IgnoreCase)?.Value, out ignoreCase))
             {
-                ignoreCase = true; // default
+                ignoreCase = true;
             }
 
             bool negate;
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             LogicalGrouping grouping;
-            if (!Enum.TryParse(conditions.Attribute(RewriteTags.MatchType)?.Value, true, out grouping))
+            if (!Enum.TryParse(conditions.Attribute(RewriteTags.MatchType)?.Value, ignoreCase:true, result:out grouping))
             {
                 grouping = LogicalGrouping.MatchAll;
             }
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             MatchType matchType;
-            if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType)?.Value, true, out matchType))
+            if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType)?.Value, ignoreCase:true, result:out matchType))
             {
                 matchType = MatchType.Pattern;
             }
@@ -195,7 +195,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
         private void ParseUrlAction(XElement urlAction, UrlRewriteRuleBuilder builder, bool stopProcessing)
         {
             ActionType actionType;
-            if (!Enum.TryParse(urlAction.Attribute(RewriteTags.Type)?.Value, true, out actionType))
+            if (!Enum.TryParse(urlAction.Attribute(RewriteTags.Type)?.Value, ignoreCase:true, result:out actionType))
             {
                 actionType = ActionType.None;
             }
@@ -207,9 +207,16 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             RedirectType redirectType;
-            if (!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType)?.Value, true, out redirectType))
+            if(urlAction.Attribute(RewriteTags.RedirectType) == null)
             {
                 redirectType = RedirectType.Permanent;
+            }
+            else
+            {
+                if(!Enum.TryParse(urlAction.Attribute(RewriteTags.RedirectType)?.Value, ignoreCase: true, result: out redirectType))
+                {
+                    ThrowParameterFormatException(urlAction, "The redirectType parameter was unrecognized");
+                }
             }
 
             string url = string.Empty;
@@ -245,6 +252,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             var line = ((IXmlLineInfo)element).LineNumber;
             var col = ((IXmlLineInfo)element).LinePosition;
             throw new FormatException(Resources.FormatError_UrlRewriteParseError(message, line, col), ex);
+        }
+
+        private static void ThrowParameterFormatException(XElement element, string message)
+        {
+            var line = ((IXmlLineInfo)element).LineNumber;
+            var col = ((IXmlLineInfo)element).LinePosition;
+            throw new FormatException(Resources.FormatError_UrlRewriteParseError(message, line, col));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             MatchType matchType;
             if (!Enum.TryParse(condition.Attribute(RewriteTags.MatchType)?.Value, true, out matchType))
             {
-                matchType = MatchType.pattern;
+                matchType = MatchType.Pattern;
             }
 
             var parsedInputString = condition.Attribute(RewriteTags.Input)?.Value;

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 
         public void AddUrlCondition(Pattern input, string pattern, PatternSyntax patternSyntax, MatchType matchType, bool ignoreCase, bool negate)
         {
-            // If there are no conditions specified,
+            // If there are no conditions specified
             if (_conditions == null)
             {
                 AddUrlConditions(LogicalGrouping.MatchAll, trackingAllCaptures: false);

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 
         public void AddUrlCondition(Pattern input, string pattern, PatternSyntax patternSyntax, MatchType matchType, bool ignoreCase, bool negate)
         {
-            // If there are no conditions specified, 
+            // If there are no conditions specified,
             if (_conditions == null)
             {
                 AddUrlConditions(LogicalGrouping.MatchAll, trackingAllCaptures: false);
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                     {
                         switch (matchType)
                         {
-                            case MatchType.pattern:
+                            case MatchType.Pattern:
                                 {
                                     if (string.IsNullOrEmpty(pattern))
                                     {
@@ -114,12 +114,12 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                                     _conditions.Add(new Condition { Input = input, Match = new RegexMatch(regex, negate), OrNext = _matchAny });
                                     break;
                                 }
-                            case MatchType.isDirectory:
+                            case MatchType.IsDirectory:
                                 {
                                     _conditions.Add(new Condition { Input = input, Match = new IsDirectoryMatch(negate), OrNext = _matchAny });
                                     break;
                                 }
-                            case MatchType.isFile:
+                            case MatchType.IsFile:
                                 {
                                     _conditions.Add(new Condition { Input = input, Match = new IsFileMatch(negate), OrNext = _matchAny });
                                     break;

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                     {
                         switch (matchType)
                         {
-                            case MatchType.Pattern:
+                            case MatchType.pattern:
                                 {
                                     if (string.IsNullOrEmpty(pattern))
                                     {

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                         }
                         break;
                     }
-                case PatternSyntax.WildCard:
+                case PatternSyntax.Wildcard:
                     throw new NotSupportedException("Wildcard syntax is not supported");
                 case PatternSyntax.ExactMatch:
                     _initialMatch = new ExactMatch(ignoreCase, input, negate);
@@ -114,12 +114,12 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                                     _conditions.Add(new Condition { Input = input, Match = new RegexMatch(regex, negate), OrNext = _matchAny });
                                     break;
                                 }
-                            case MatchType.IsDirectory:
+                            case MatchType.isDirectory:
                                 {
                                     _conditions.Add(new Condition { Input = input, Match = new IsDirectoryMatch(negate), OrNext = _matchAny });
                                     break;
                                 }
-                            case MatchType.IsFile:
+                            case MatchType.isFile:
                                 {
                                     _conditions.Add(new Condition { Input = input, Match = new IsFileMatch(negate), OrNext = _matchAny });
                                     break;
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                         }
                         break;
                     }
-                case PatternSyntax.WildCard:
+                case PatternSyntax.Wildcard:
                     throw new NotSupportedException("Wildcard syntax is not supported");
                 case PatternSyntax.ExactMatch:
                     if (pattern == null)

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
@@ -111,6 +111,52 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
     </rules>
 </rewrite>",
             "Could not parse the UrlRewrite file. Message: 'The redirectType parameter was unrecognized'. Line number '5': '14'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$"" />
+            <action type=""foo"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The action type parameter was not recognized'. Line number '5': '14'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$"" />
+            <conditions logicalGrouping=""foo"">
+                <add input=""{REQUEST_FILENAME}"" matchType=""isFile"" negate=""true""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The logicalGrouping parameter was not recognized'. Line number '5': '14'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"" patternSyntax=""foo"">
+            <match url = ""(.*)/$"" />
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The patternSyntax parameter was not recognized'. Line number '3': '10'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$"" />
+            <conditions>
+                <add input=""{REQUEST_FILENAME}"" matchType=""foo"" negate=""true""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The matchType parameter wasn't recognized'. Line number '6': '18'.")]
         public void ThrowFormatExceptionWithCorrectMessage(string input, string expected)
         {
             // Arrange, Act, Assert

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
@@ -101,6 +101,16 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
     </rules>
 </rewrite>",
             "Could not parse the UrlRewrite file. Message: 'Url attribute cannot contain an empty string'. Line number '5': '14'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$"" />
+            <action type=""Redirect"" redirectType=""foo"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The redirectType parameter was unrecognized'. Line number '5': '14'.")]
         public void ThrowFormatExceptionWithCorrectMessage(string input, string expected)
         {
             // Arrange, Act, Assert

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The redirectType parameter 'foo' was unrecognized'. Line number '5': '14'.")]
+            "Could not parse the UrlRewrite file. Message: 'The redirectType parameter 'foo' was not recognized'. Line number '5': '14'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -156,7 +156,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The matchType parameter 'foo' wasn't recognized'. Line number '6': '18'.")]
+            "Could not parse the UrlRewrite file. Message: 'The matchType parameter 'foo' was not recognized'. Line number '6': '18'.")]
         public void ThrowFormatExceptionWithCorrectMessage(string input, string expected)
         {
             // Arrange, Act, Assert

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The redirectType parameter: foo, was unrecognized'. Line number '5': '14'.")]
+            "Could not parse the UrlRewrite file. Message: 'The redirectType parameter 'foo' was unrecognized'. Line number '5': '14'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The type parameter: foo, was not recognized'. Line number '5': '14'.")]
+            "Could not parse the UrlRewrite file. Message: 'The type parameter 'foo' was not recognized'. Line number '5': '14'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The logicalGrouping parameter: foo, was not recognized'. Line number '5': '14'.")]
+            "Could not parse the UrlRewrite file. Message: 'The logicalGrouping parameter 'foo' was not recognized'. Line number '5': '14'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The patternSyntax parameter: foo, was not recognized'. Line number '3': '10'.")]
+            "Could not parse the UrlRewrite file. Message: 'The patternSyntax parameter 'foo' was not recognized'. Line number '3': '10'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -156,7 +156,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The matchType parameter: foo, wasn't recognized'. Line number '6': '18'.")]
+            "Could not parse the UrlRewrite file. Message: 'The matchType parameter 'foo' wasn't recognized'. Line number '6': '18'.")]
         public void ThrowFormatExceptionWithCorrectMessage(string input, string expected)
         {
             // Arrange, Act, Assert

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The redirectType parameter was unrecognized'. Line number '5': '14'.")]
+            "Could not parse the UrlRewrite file. Message: 'The redirectType parameter: foo, was unrecognized'. Line number '5': '14'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The action type parameter was not recognized'. Line number '5': '14'.")]
+            "Could not parse the UrlRewrite file. Message: 'The type parameter: foo, was not recognized'. Line number '5': '14'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The logicalGrouping parameter was not recognized'. Line number '5': '14'.")]
+            "Could not parse the UrlRewrite file. Message: 'The logicalGrouping parameter: foo, was not recognized'. Line number '5': '14'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The patternSyntax parameter was not recognized'. Line number '3': '10'.")]
+            "Could not parse the UrlRewrite file. Message: 'The patternSyntax parameter: foo, was not recognized'. Line number '3': '10'.")]
         [InlineData(
 @"<rewrite>
     <rules>
@@ -156,7 +156,7 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
         </rule>
     </rules>
 </rewrite>",
-            "Could not parse the UrlRewrite file. Message: 'The matchType parameter wasn't recognized'. Line number '6': '18'.")]
+            "Could not parse the UrlRewrite file. Message: 'The matchType parameter: foo, wasn't recognized'. Line number '6': '18'.")]
         public void ThrowFormatExceptionWithCorrectMessage(string input, string expected)
         {
             // Arrange, Act, Assert

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/MiddleWareTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/MiddleWareTests.cs
@@ -337,18 +337,21 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
             Assert.Equal(response.Headers.Location.OriginalString, "/foo");
         }
 
-        [Fact]
-        public async Task VerifyIsFileAndIsDirectoryParsing()
+        [Theory]
+        [InlineData("IsFile")]
+        [InlineData("isfile")]
+        [InlineData("IsDirectory")]
+        [InlineData("isdirectory")]
+        public async Task VerifyIsFileAndIsDirectoryParsing(string matchType)
         {
-            var options = new RewriteOptions().AddIISUrlRewrite(new StringReader(@"<rewrite>
+            var options = new RewriteOptions().AddIISUrlRewrite(new StringReader($@"<rewrite>
                 <rules>
                 <rule name=""Test"">
                 <match url=""(.*[^/])$"" />
                 <conditions>
-                <add input=""{REQUEST_FILENAME}"" matchType=""iSfIlE"" negate=""true""/>
-                <add input=""{REQUEST_FILENAME}"" matchType=""iSdIrEctOrY"" negate=""true""/>
+                <add input=""{{REQUEST_FILENAME}}"" matchType=""{matchType}"" negate=""true""/>
                 </conditions>
-                <action type=""Redirect"" url=""{R:1}/"" />
+                <action type=""Redirect"" url=""{{R:1}}/"" />
                 </rule>
                 </rules>
                 </rewrite>"));

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/MiddleWareTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/MiddleWareTests.cs
@@ -336,5 +336,32 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
 
             Assert.Equal(response.Headers.Location.OriginalString, "/foo");
         }
+
+        [Fact]
+        public async Task VerifyIsFileAndIsDirectoryParsing()
+        {
+            var options = new RewriteOptions().AddIISUrlRewrite(new StringReader(@"<rewrite>
+                <rules>
+                <rule name=""Test"">
+                <match url=""(.*[^/])$"" />
+                <conditions>
+                <add input=""{REQUEST_FILENAME}"" matchType=""iSfIlE"" negate=""true""/>
+                <add input=""{REQUEST_FILENAME}"" matchType=""iSdIrEctOrY"" negate=""true""/>
+                </conditions>
+                <action type=""Redirect"" url=""{R:1}/"" />
+                </rule>
+                </rules>
+                </rewrite>"));
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseRewriter(options);
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync("hey/hello");
+
+            Assert.Equal("/hey/hello/", response.Headers.Location.OriginalString); ;
+        }
     }
 }


### PR DESCRIPTION
Currently enum parsing isn't case sensitive and some of the enums have incorrect casing which is a bad combo..
Issue: https://github.com/aspnet/BasicMiddleware/issues/145
@BrennanConroy @natemcmaster @Tratcher 