### PR TITLE
Fix url rewrite bool parsing

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -60,9 +60,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             builder.Name = rule.Attribute(RewriteTags.Name)?.Value;
 
             bool enabled;
-            if (!bool.TryParse(rule.Attribute(RewriteTags.Enabled)?.Value, out enabled))
+            if (rule.Attribute(RewriteTags.Enabled) == null)
             {
                 builder.Enabled = true;
+            }
+            else if (!bool.TryParse(rule.Attribute(RewriteTags.Enabled).Value, out enabled))
+            {
+                ThrowParameterFormatException(rule, $"The {RewriteTags.Enabled} parameter '{rule.Attribute(RewriteTags.Enabled).Value}' was not recognized");
             }
             else
             {
@@ -87,9 +91,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             bool stopProcessing;
-            if (!bool.TryParse(rule.Attribute(RewriteTags.StopProcessing)?.Value, out stopProcessing))
+            if (rule.Attribute(RewriteTags.StopProcessing) == null)
             {
                 stopProcessing = false;
+            }
+            else if (!bool.TryParse(rule.Attribute(RewriteTags.StopProcessing).Value, out stopProcessing))
+            {
+                ThrowParameterFormatException(rule, $"The {RewriteTags.StopProcessing} parameter '{rule.Attribute(RewriteTags.StopProcessing).Value}' was not recognized");
             }
 
             var match = rule.Element(RewriteTags.Match);
@@ -118,15 +126,23 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             bool ignoreCase;
-            if (!bool.TryParse(match.Attribute(RewriteTags.IgnoreCase)?.Value, out ignoreCase))
+            if (match.Attribute(RewriteTags.IgnoreCase) == null)
             {
                 ignoreCase = true;
             }
+            else if (!bool.TryParse(match.Attribute(RewriteTags.IgnoreCase).Value, out ignoreCase))
+            {
+                ThrowParameterFormatException(match, $"The {RewriteTags.IgnoreCase} parameter '{match.Attribute(RewriteTags.IgnoreCase).Value}' was not recognized");
+            }
 
             bool negate;
-            if (!bool.TryParse(match.Attribute(RewriteTags.Negate)?.Value, out negate))
+            if(match.Attribute(RewriteTags.Negate) == null)
             {
                 negate = false;
+            }
+            else if (!bool.TryParse(match.Attribute(RewriteTags.Negate).Value, out negate))
+            {
+                ThrowParameterFormatException(match, $"The {RewriteTags.Negate} parameter '{match.Attribute(RewriteTags.Negate).Value}' was not recognized");
             }
             builder.AddUrlMatch(parsedInputString, ignoreCase, negate, patternSyntax);
         }
@@ -149,9 +165,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             bool trackingAllCaptures;
-            if (!bool.TryParse(conditions.Attribute(RewriteTags.TrackingAllCaptures)?.Value, out trackingAllCaptures))
+            if (conditions.Attribute(RewriteTags.TrackingAllCaptures) == null)
             {
                 trackingAllCaptures = false;
+            }
+            else if (!bool.TryParse(conditions.Attribute(RewriteTags.TrackingAllCaptures)?.Value, out trackingAllCaptures))
+            {
+                ThrowParameterFormatException(conditions, $"The {RewriteTags.TrackingAllCaptures} parameter '{conditions.Attribute(RewriteTags.TrackingAllCaptures).Value}' was not recognized");
             }
 
             builder.AddUrlConditions(grouping, trackingAllCaptures);
@@ -165,15 +185,23 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
         private void ParseCondition(XElement condition, UrlRewriteRuleBuilder builder, PatternSyntax patternSyntax)
         {
             bool ignoreCase;
-            if (!bool.TryParse(condition.Attribute(RewriteTags.IgnoreCase)?.Value, out ignoreCase))
+            if (condition.Attribute(RewriteTags.IgnoreCase) == null)
             {
                 ignoreCase = true;
             }
+            else if (!bool.TryParse(condition.Attribute(RewriteTags.IgnoreCase).Value, out ignoreCase))
+            {
+                ThrowParameterFormatException(condition, $"The {RewriteTags.IgnoreCase} parameter '{condition.Attribute(RewriteTags.IgnoreCase).Value}' was not recognized");
+            }
 
             bool negate;
-            if (!bool.TryParse(condition.Attribute(RewriteTags.Negate)?.Value, out negate))
+            if(condition.Attribute(RewriteTags.Negate) == null)
             {
                 negate = false;
+            }
+            else if (!bool.TryParse(condition.Attribute(RewriteTags.Negate).Value, out negate))
+            {
+                ThrowParameterFormatException(condition, $"The {RewriteTags.Negate} parameter '{condition.Attribute(RewriteTags.Negate).Value}' was not recognized");
             }
 
             MatchType matchType;
@@ -217,9 +245,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             }
 
             bool appendQuery;
-            if (!bool.TryParse(urlAction.Attribute(RewriteTags.AppendQueryString)?.Value, out appendQuery))
+            if (urlAction.Attribute(RewriteTags.AppendQueryString) == null)
             {
                 appendQuery = true;
+            }
+            else if (!bool.TryParse(urlAction.Attribute(RewriteTags.AppendQueryString).Value, out appendQuery))
+            {
+                ThrowParameterFormatException(urlAction, $"The {RewriteTags.AppendQueryString} parameter '{urlAction.Attribute(RewriteTags.AppendQueryString).Value}' was not recognized");
             }
 
             RedirectType redirectType;

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             {
                 trackingAllCaptures = false;
             }
-            else if (!bool.TryParse(conditions.Attribute(RewriteTags.TrackingAllCaptures)?.Value, out trackingAllCaptures))
+            else if (!bool.TryParse(conditions.Attribute(RewriteTags.TrackingAllCaptures).Value, out trackingAllCaptures))
             {
                 ThrowParameterFormatException(conditions, $"The {RewriteTags.TrackingAllCaptures} parameter '{conditions.Attribute(RewriteTags.TrackingAllCaptures).Value}' was not recognized");
             }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -208,19 +208,16 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             return result;
         }
 
-        private T ParseEnum<T>(XElement element, string rewriteTag, T defaultValue)
+        private TEnum ParseEnum<TEnum>(XElement element, string rewriteTag, TEnum defaultValue)
+            where TEnum : struct
         {
-            T enumResult = default(T);
+            TEnum enumResult = default(TEnum);
             var attribute = element.Attribute(rewriteTag);
             if (attribute == null)
             {
                 return defaultValue;
             }
-            try
-            {
-                enumResult = (T)Enum.Parse(typeof(T), attribute.Value, ignoreCase: true);
-            }
-            catch
+            else if(!Enum.TryParse(attribute.Value, ignoreCase: true, result: out enumResult))
             {
                 ThrowParameterFormatException(element, $"The {rewriteTag} parameter '{attribute.Value}' was not recognized");
             }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -59,25 +59,13 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
         {
             builder.Name = rule.Attribute(RewriteTags.Name)?.Value;
 
-            bool enabled;
-            if (rule.Attribute(RewriteTags.Enabled) == null)
+            if (ParseBool(rule, RewriteTags.Enabled, defaultValue: true))
             {
                 builder.Enabled = true;
             }
-            else if (!bool.TryParse(rule.Attribute(RewriteTags.Enabled).Value, out enabled))
-            {
-                ThrowParameterFormatException(rule, $"The {RewriteTags.Enabled} parameter '{rule.Attribute(RewriteTags.Enabled).Value}' was not recognized");
-            }
             else
             {
-                if (enabled)
-                {
-                    builder.Enabled = enabled;
-                }
-                else
-                {
-                    return;
-                }
+                return;
             }
 
             PatternSyntax patternSyntax;
@@ -90,15 +78,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                 ThrowParameterFormatException(rule, $"The {RewriteTags.PatternSyntax} parameter '{rule.Attribute(RewriteTags.PatternSyntax).Value}' was not recognized");
             }
 
-            bool stopProcessing;
-            if (rule.Attribute(RewriteTags.StopProcessing) == null)
-            {
-                stopProcessing = false;
-            }
-            else if (!bool.TryParse(rule.Attribute(RewriteTags.StopProcessing).Value, out stopProcessing))
-            {
-                ThrowParameterFormatException(rule, $"The {RewriteTags.StopProcessing} parameter '{rule.Attribute(RewriteTags.StopProcessing).Value}' was not recognized");
-            }
+            var stopProcessing = ParseBool(rule, RewriteTags.StopProcessing, defaultValue: false);
 
             var match = rule.Element(RewriteTags.Match);
             if (match == null)
@@ -125,25 +105,8 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                 ThrowUrlFormatException(match, "Match must have Url Attribute");
             }
 
-            bool ignoreCase;
-            if (match.Attribute(RewriteTags.IgnoreCase) == null)
-            {
-                ignoreCase = true;
-            }
-            else if (!bool.TryParse(match.Attribute(RewriteTags.IgnoreCase).Value, out ignoreCase))
-            {
-                ThrowParameterFormatException(match, $"The {RewriteTags.IgnoreCase} parameter '{match.Attribute(RewriteTags.IgnoreCase).Value}' was not recognized");
-            }
-
-            bool negate;
-            if(match.Attribute(RewriteTags.Negate) == null)
-            {
-                negate = false;
-            }
-            else if (!bool.TryParse(match.Attribute(RewriteTags.Negate).Value, out negate))
-            {
-                ThrowParameterFormatException(match, $"The {RewriteTags.Negate} parameter '{match.Attribute(RewriteTags.Negate).Value}' was not recognized");
-            }
+            var ignoreCase = ParseBool(match, RewriteTags.IgnoreCase, defaultValue: true);
+            var negate = ParseBool(match, RewriteTags.Negate, defaultValue: false);
             builder.AddUrlMatch(parsedInputString, ignoreCase, negate, patternSyntax);
         }
 
@@ -164,16 +127,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                 ThrowParameterFormatException(conditions, $"The {RewriteTags.LogicalGrouping} parameter '{conditions.Attribute(RewriteTags.LogicalGrouping).Value}' was not recognized");
             }
 
-            bool trackingAllCaptures;
-            if (conditions.Attribute(RewriteTags.TrackingAllCaptures) == null)
-            {
-                trackingAllCaptures = false;
-            }
-            else if (!bool.TryParse(conditions.Attribute(RewriteTags.TrackingAllCaptures).Value, out trackingAllCaptures))
-            {
-                ThrowParameterFormatException(conditions, $"The {RewriteTags.TrackingAllCaptures} parameter '{conditions.Attribute(RewriteTags.TrackingAllCaptures).Value}' was not recognized");
-            }
-
+            var trackingAllCaptures = ParseBool(conditions, RewriteTags.TrackingAllCaptures, defaultValue: false);
             builder.AddUrlConditions(grouping, trackingAllCaptures);
 
             foreach (var cond in conditions.Elements(RewriteTags.Add))
@@ -184,25 +138,8 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 
         private void ParseCondition(XElement condition, UrlRewriteRuleBuilder builder, PatternSyntax patternSyntax)
         {
-            bool ignoreCase;
-            if (condition.Attribute(RewriteTags.IgnoreCase) == null)
-            {
-                ignoreCase = true;
-            }
-            else if (!bool.TryParse(condition.Attribute(RewriteTags.IgnoreCase).Value, out ignoreCase))
-            {
-                ThrowParameterFormatException(condition, $"The {RewriteTags.IgnoreCase} parameter '{condition.Attribute(RewriteTags.IgnoreCase).Value}' was not recognized");
-            }
-
-            bool negate;
-            if(condition.Attribute(RewriteTags.Negate) == null)
-            {
-                negate = false;
-            }
-            else if (!bool.TryParse(condition.Attribute(RewriteTags.Negate).Value, out negate))
-            {
-                ThrowParameterFormatException(condition, $"The {RewriteTags.Negate} parameter '{condition.Attribute(RewriteTags.Negate).Value}' was not recognized");
-            }
+            var ignoreCase = ParseBool(condition, RewriteTags.IgnoreCase, defaultValue: true);
+            var negate = ParseBool(condition, RewriteTags.Negate, defaultValue: false);
 
             MatchType matchType;
             if (condition.Attribute(RewriteTags.MatchType) == null)
@@ -244,15 +181,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                 ThrowParameterFormatException(urlAction, $"The {RewriteTags.Type} parameter '{urlAction.Attribute(RewriteTags.Type).Value}' was not recognized");
             }
 
-            bool appendQuery;
-            if (urlAction.Attribute(RewriteTags.AppendQueryString) == null)
-            {
-                appendQuery = true;
-            }
-            else if (!bool.TryParse(urlAction.Attribute(RewriteTags.AppendQueryString).Value, out appendQuery))
-            {
-                ThrowParameterFormatException(urlAction, $"The {RewriteTags.AppendQueryString} parameter '{urlAction.Attribute(RewriteTags.AppendQueryString).Value}' was not recognized");
-            }
+            var appendQuery = ParseBool(urlAction, RewriteTags.AppendQueryString, defaultValue: true);
 
             RedirectType redirectType;
             if (urlAction.Attribute(RewriteTags.RedirectType) == null)
@@ -307,6 +236,21 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
             var line = lineInfo.LineNumber;
             var col = lineInfo.LinePosition;
             throw new FormatException(Resources.FormatError_UrlRewriteParseError(message, line, col));
+        }
+
+        private bool ParseBool(XElement element, string rewriteTag, bool defaultValue)
+        {
+            bool result;
+            var attribute = element.Attribute(rewriteTag);
+            if (attribute == null)
+            {
+                return defaultValue;
+            }
+            else if (!bool.TryParse(attribute.Value, out result))
+            {
+                ThrowParameterFormatException(element, $"The {rewriteTag} parameter '{attribute.Value}' was not recognized");
+            }
+            return result;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/IISUrlRewrite/FormatExceptionHandlingTests.cs
@@ -157,6 +157,107 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite
     </rules>
 </rewrite>",
             "Could not parse the UrlRewrite file. Message: 'The matchType parameter 'foo' was not recognized'. Line number '6': '18'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"" enabled=""foo"">
+            <match url = ""(.*)/$"" />
+            <conditions>
+                <add input=""{REQUEST_FILENAME}"" negate=""true""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The enabled parameter 'foo' was not recognized'. Line number '3': '10'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"" stopProcessing=""foo"">
+            <match url = ""(.*)/$"" />
+            <conditions>
+                <add input=""{REQUEST_FILENAME}"" negate=""true""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The stopProcessing parameter 'foo' was not recognized'. Line number '3': '10'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$"" ignoreCase=""foo""/>
+            <conditions>
+                <add input=""{REQUEST_FILENAME}"" negate=""true""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The ignoreCase parameter 'foo' was not recognized'. Line number '4': '14'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$""/>
+            <conditions>
+                <add input=""{REQUEST_FILENAME}"" ignoreCase=""foo""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The ignoreCase parameter 'foo' was not recognized'. Line number '6': '18'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$"" negate=""foo""/>
+            <conditions>
+                <add input=""{REQUEST_FILENAME}""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The negate parameter 'foo' was not recognized'. Line number '4': '14'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$""/>
+            <conditions>
+                <add input=""{REQUEST_FILENAME}"" negate=""foo""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The negate parameter 'foo' was not recognized'. Line number '6': '18'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$""/>
+            <conditions trackingAllCaptures=""foo"">
+                <add input=""{REQUEST_FILENAME}""/>
+            </conditions>
+            <action type=""Redirect"" url =""{R:1}"" />
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The trackingAllCaptures parameter 'foo' was not recognized'. Line number '5': '14'.")]
+        [InlineData(
+@"<rewrite>
+    <rules>
+        <rule name=""Remove trailing slash"">
+            <match url = ""(.*)/$""/>
+            <action type=""Redirect"" url =""{R:1}"" appendQueryString=""foo""/>
+        </rule>
+    </rules>
+</rewrite>",
+            "Could not parse the UrlRewrite file. Message: 'The appendQueryString parameter 'foo' was not recognized'. Line number '5': '14'.")]
         public void ThrowFormatExceptionWithCorrectMessage(string input, string expected)
         {
             // Arrange, Act, Assert


### PR DESCRIPTION
Fixes https://github.com/aspnet/BasicMiddleware/issues/161
This change makes url rewrite file parsing throw for bad values for Boolean parameters and only provides defaults when the attributes aren't present.

@Tratcher @natemcmaster @BrennanConroy 
