### PR TITLE
Added default status code for mod_rewrite redirect

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/FlagParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/FlagParser.cs
@@ -75,17 +75,21 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
             var flags = new Flags();
             foreach (var token in tokens)
             {
-                var hasPayload = token.Split('=');
+                var payload = token.Split('=');
 
                 FlagType flag;
-                if (!_ruleFlagLookup.TryGetValue(hasPayload[0], out flag))
+                if (!_ruleFlagLookup.TryGetValue(payload[0], out flag))
                 {
-                    throw new FormatException($"Unrecognized flag: '{hasPayload[0]}'");
+                    throw new FormatException($"Unrecognized flag: '{payload[0]}'");
                 }
 
-                if (hasPayload.Length == 2)
+                if (payload.Length == 2)
                 {
-                    flags.SetFlag(flag, hasPayload[1]);
+                    flags.SetFlag(flag, payload[1]);
+                }
+                else if (string.Equals(payload[0], "R", StringComparison.OrdinalIgnoreCase))
+                {
+                    flags.SetFlag(flag, "302");
                 }
                 else
                 {

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/ApacheModRewrite/FlagParserTest.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/ApacheModRewrite/FlagParserTest.cs
@@ -48,6 +48,17 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.ModRewrite
             Assert.True(DictionaryContentsEqual(expected.FlagDictionary, results.FlagDictionary));
         }
 
+        [Fact]
+        public void FlagParser_CheckDefaultRedirectStatusCode()
+        {
+            var results = new FlagParser().Parse("[R]");
+            var dict = new Dictionary<FlagType, string>();
+            dict.Add(FlagType.Redirect, "302");
+            var expected = new Flags(dict);
+
+            Assert.True(DictionaryContentsEqual(expected.FlagDictionary, results.FlagDictionary));
+        }
+
         [Theory]
         [InlineData("]", "Flags should start and end with square brackets: [flags]")]
         [InlineData("[", "Flags should start and end with square brackets: [flags]")]


### PR DESCRIPTION
Currently the middleware throws when there is no status code with the redirect flag. It should default to 302.
Addresses https://github.com/aspnet/BasicMiddleware/issues/152
@BrennanConroy @Tratcher @natemcmaster 