### PR TITLE
Added more GZIP compressable MIME types

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionDefaults.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionDefaults.cs
@@ -18,15 +18,22 @@ namespace Microsoft.AspNetCore.ResponseCompression
         {
             // General
             "text/plain",
-            // Static files
             "text/css",
             "application/javascript",
-            // MVC
             "text/html",
             "application/xml",
             "text/xml",
+            "application/rss+xml",
+            "application/atom+xml",
             "application/json",
-            "text/json",
+            "text/json"
+            // Images
+            "image/svg+xml",
+            "image/x-icon",
+            // Fonts
+            "application/vnd.ms-fontobject",
+            "application/x-font-ttf",
+            "font/otf"
         };
     }
 }

--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionDefaults.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionDefaults.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             "application/rss+xml",
             "application/atom+xml",
             "application/json",
-            "text/json"
+            "text/json",
             // Images
             "image/svg+xml",
             "image/x-icon",


### PR DESCRIPTION
The MIME type list for what can be compressed is a bit basic. There are several other formats which can be compressed, including images and font file formats.