### PR TITLE
add StringBuilder pool

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/Internal/Pattern.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/Pattern.cs
@@ -15,13 +15,20 @@ namespace Microsoft.AspNetCore.Rewrite.Internal
 
         public string Evaluate(RewriteContext context, BackReferenceCollection ruleBackReferences, BackReferenceCollection conditionBackReferences)
         {
-            foreach (var pattern in PatternSegments)
+            var pooledBuilder = PooledStringBuilder.Allocate();
+            try
             {
-                context.Builder.Append(pattern.Evaluate(context, ruleBackReferences, conditionBackReferences));
+                var builder = pooledBuilder.Builder;
+                foreach (var pattern in PatternSegments)
+                {
+                    builder.Append(pattern.Evaluate(context, ruleBackReferences, conditionBackReferences));
+                }
+                return builder.ToString();
             }
-            var retVal = context.Builder.ToString();
-            context.Builder.Clear();
-            return retVal;
+            finally
+            {
+                pooledBuilder.Free();
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/PatternSegments/ToLowerSegment.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/PatternSegments/ToLowerSegment.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Text;
-
 namespace Microsoft.AspNetCore.Rewrite.Internal.PatternSegments
 {
     public class ToLowerSegment : PatternSegment
@@ -16,12 +14,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.PatternSegments
 
         public override string Evaluate(RewriteContext context, BackReferenceCollection ruleBackReferences, BackReferenceCollection conditionBackReferences)
         {
-            // PERF as we share the string builder across the context, we need to make a new one here to evaluate
-            // lowercase segments.
-            var tempBuilder = context.Builder;
-            context.Builder = new StringBuilder(64);
             var pattern = _pattern.Evaluate(context, ruleBackReferences, conditionBackReferences);
-            context.Builder = tempBuilder;
             return pattern.ToLowerInvariant();
         }
     }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/PatternSegments/UrlEncodeSegment.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/PatternSegments/UrlEncodeSegment.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Text;
 using System.Text.Encodings.Web;
 
 namespace Microsoft.AspNetCore.Rewrite.Internal.PatternSegments
@@ -17,14 +16,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.PatternSegments
 
         public override string Evaluate(RewriteContext context, BackReferenceCollection ruleBackReferences, BackReferenceCollection conditionBackReferences)
         {
-            var oldBuilder = context.Builder;
-            // PERF 
-            // Because we need to be able to evaluate multiple nested patterns,
-            // we provided a new string builder and evaluate the new pattern,
-            // and restore it after evaluation.
-            context.Builder = new StringBuilder(64);
             var pattern = _pattern.Evaluate(context, ruleBackReferences, conditionBackReferences);
-            context.Builder = oldBuilder;
             return UrlEncoder.Default.Encode(pattern);
         }
     }

--- a/src/Microsoft.AspNetCore.Rewrite/ObjectPool.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/ObjectPool.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+
+namespace Microsoft.AspNetCore.Rewrite
+{
+    public class ObjectPool<T>
+    {
+        private readonly Func<T> _objectFactory;
+        private readonly BlockingCollection<T> _objects;
+
+        public ObjectPool(Func<T> objectFactory, int poolSize)
+        {
+            _objectFactory = objectFactory ?? throw new ArgumentNullException(nameof(objectFactory));
+            _objects = new BlockingCollection<T>(new ConcurrentBag<T>(), poolSize);
+        }
+
+        public T Allocate()
+        {
+            T item;
+            return _objects.TryTake(out item) ? item : _objectFactory();
+        }
+
+        public void Free(T item)
+        {
+            _objects.TryAdd(item);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Rewrite/PooledStringBuilder.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/PooledStringBuilder.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Rewrite
+{
+    public class PooledStringBuilder
+    {
+        private static readonly ObjectPool<PooledStringBuilder> _sGlobalPool = CreatePool(Environment.ProcessorCount * 2);
+
+        public readonly StringBuilder Builder = new StringBuilder();
+        private readonly ObjectPool<PooledStringBuilder> _pool;
+
+        private PooledStringBuilder(ObjectPool<PooledStringBuilder> pool)
+        {
+            _pool = pool ?? throw new ArgumentNullException(nameof(pool));
+        }
+
+        public int Length => Builder.Length;
+
+        public void Free()
+        {
+            StringBuilder builder = Builder;
+
+            // do not store builders that are too large.
+            if (builder.Capacity > 1024)
+            {
+                return;
+            }
+
+            builder.Clear();
+            _pool.Free(this);
+        }
+
+        [Obsolete("Consider calling " + nameof(ToStringAndFree) + " instead.")]
+        public new string ToString()
+        {
+            return Builder.ToString();
+        }
+
+        public string ToStringAndFree()
+        {
+            string result = Builder.ToString();
+            Free();
+
+            return result;
+        }
+
+        public string ToStringAndFree(int startIndex, int length)
+        {
+            string result = Builder.ToString(startIndex, length);
+            Free();
+
+            return result;
+        }
+
+        public static ObjectPool<PooledStringBuilder> CreatePool(int size = 32)
+        {
+            ObjectPool<PooledStringBuilder> pool = null;
+            pool = new ObjectPool<PooledStringBuilder>(() => new PooledStringBuilder(pool), size);
+            return pool;
+        }
+
+        public static PooledStringBuilder Allocate()
+        {
+            PooledStringBuilder builder = _sGlobalPool.Allocate();
+            if (builder.Builder.Length != 0)
+            {
+                throw new InvalidOperationException("Builder in use");
+            }
+            return builder;
+        }
+
+        public static implicit operator StringBuilder(PooledStringBuilder obj)
+        {
+            return obj.Builder;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Rewrite/RewriteContext.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/RewriteContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
@@ -33,7 +32,5 @@ namespace Microsoft.AspNetCore.Rewrite
         /// should be taken. See <see cref="RuleResult"/>
         /// </summary>
         public RuleResult Result { get; set; }
-
-        internal StringBuilder Builder { get; set; } = new StringBuilder(64);
     }
 }


### PR DESCRIPTION
Add pooling for StringBuilder. This PR addresses the perf concerns noted in a couple of the `Segment` classes. The implementation of `PooledStringBuilder` is borrowed from http://source.roslyn.codeplex.com/#Microsoft.CodeAnalysis.Workspaces/PooledStringBuilder.cs. The implementation of `ObjectPool` is inspired by https://msdn.microsoft.com/en-us/library/ff458671%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396 rather than also borrowing http://source.roslyn.codeplex.com/#Microsoft.CodeAnalysis.Workspaces/ObjectPool%25601.cs. Obviously it would be trivial to switch the implementation out.

I decided to add this as a PR because I ran into needing an additional `StringBuilder` in a PR I'm about to add for adding header support in rewrite rules. Rather than copying and pasting the same perf code in yet another segment, I cleaned it up.