### PR TITLE
Change RequireHeaderSymmetry default to false, improve consistency.

### DIFF
--- a/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersMiddleware.cs
@@ -164,9 +164,15 @@ namespace Microsoft.AspNetCore.HttpOverrides
                         currentValues.IpAndPortText = set.IpAndPortText;
                         currentValues.RemoteIpAndPort = set.RemoteIpAndPort;
                     }
+                    else if (!string.IsNullOrEmpty(set.IpAndPortText))
+                    {
+                        // Stop at the first unparsable IP, but still apply changes processed so far.
+                        _logger.LogDebug(1, $"Unparsable IP: {set.IpAndPortText}");
+                        break;
+                    }
                     else if (_options.RequireHeaderSymmetry)
                     {
-                        _logger.LogWarning(2, $"Failed to parse forwarded IPAddress: {currentValues.IpAndPortText}");
+                        _logger.LogWarning(2, $"Missing forwarded IPAddress.");
                         return;
                     }
                 }

--- a/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersOptions.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersOptions.cs
@@ -69,8 +69,8 @@ namespace Microsoft.AspNetCore.Builder
 
         /// <summary>
         /// Require the number of header values to be in sync between the different headers being processed.
-        /// The default is 'true'.
+        /// The default is 'false'.
         /// </summary>
-        public bool RequireHeaderSymmetry { get; set; } = true;
+        public bool RequireHeaderSymmetry { get; set; } = false;
     }
 }


### PR DESCRIPTION
#190 RequireHeaderSymmetry is a paranoid level of security for forwarded headers that is broken in too many real world scenarios (including Azure). Changing the default to false.

When I changed the default I noticed some inconsistent handling of invalid IPs and cleaned that up a little.

Will follow up by removing the azure hack:
https://github.com/aspnet/IISIntegration/blob/ce3c71b5b3499e83853d9ef1ad59e1e13e65c685/src/Microsoft.AspNetCore.Server.IISIntegration/WebHostBuilderIISExtensions.cs#L61-L66