### PR TITLE
Preserve redirect query string

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/Internal/RedirectRule.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/RedirectRule.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal
                 }
                 else
                 {
-                    response.Headers[HeaderNames.Location] = pathBase + newPath;
+                    response.Headers[HeaderNames.Location] = pathBase + newPath + context.HttpContext.Request.QueryString;
                 }
 
                 context.Logger?.RedirectedSummary(newPath);

--- a/test/Microsoft.AspNetCore.Rewrite.Tests/MiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Rewrite.Tests/MiddlewareTests.cs
@@ -51,6 +51,22 @@ namespace Microsoft.AspNetCore.Rewrite.Tests.CodeRules
             Assert.Equal("http://example.com/foo", response.Headers.Location.OriginalString);
         }
 
+        [Fact]
+        public async Task CheckRedirectPathWithQueryString()
+        {
+            var options = new RewriteOptions().AddRedirect("(.*)","http://example.com/$1", statusCode: StatusCodes.Status301MovedPermanently);
+            var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.UseRewriter(options);
+            });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync("foo?bar=1");
+
+            Assert.Equal("http://example.com/foo?bar=1", response.Headers.Location.OriginalString);
+        }
+
         [Theory]
         [InlineData(StatusCodes.Status301MovedPermanently)]
         [InlineData(StatusCodes.Status302Found)]


### PR DESCRIPTION
Query strings for redirects where the redirect location did not also include a query string were being dropped. 
Resolves: https://github.com/aspnet/BasicMiddleware/issues/188

