### PR TITLE
Add option to add additional forwarders to ForwardedHeadersMiddleware

### DIFF
--- a/samples/HttpOverridesSample/Startup.cs
+++ b/samples/HttpOverridesSample/Startup.cs
@@ -2,13 +2,14 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Logging;
 
 namespace HttpOverridesSample
 {
     public class Startup
     {
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app)
+        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             app.UseForwardedHeaders(new ForwardedHeadersOptions
             {

--- a/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersDefaults.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersDefaults.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.HttpOverrides
 {
     /// <summary>
-    /// Default values related to <see cref="ForwardedHeadersMiddleware"/> middleware
+    /// Default values related to <see cref="ForwardedHeadersForwarder"/> middleware
     /// </summary>
     /// <seealso cref="Microsoft.AspNetCore.Builder.ForwardedHeadersOptions"/>
     public static class ForwardedHeadersDefaults

--- a/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersForwarder.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersForwarder.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.HttpOverrides
+{
+    public class ForwardedHeadersForwarder : Forwarder
+    {
+        private readonly ForwardedHeadersOptions _options;
+        private readonly ILogger _logger;
+
+        public ForwardedHeadersForwarder(ILoggerFactory loggerFactory, IOptions<ForwardedHeadersOptions> options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            // Make sure required options is not null or whitespace
+            EnsureOptionNotNullorWhitespace(options.Value.ForwardedForHeaderName, nameof(options.Value.ForwardedForHeaderName));
+            EnsureOptionNotNullorWhitespace(options.Value.ForwardedHostHeaderName, nameof(options.Value.ForwardedHostHeaderName));
+            EnsureOptionNotNullorWhitespace(options.Value.ForwardedProtoHeaderName, nameof(options.Value.ForwardedProtoHeaderName));
+            EnsureOptionNotNullorWhitespace(options.Value.OriginalForHeaderName, nameof(options.Value.OriginalForHeaderName));
+            EnsureOptionNotNullorWhitespace(options.Value.OriginalHostHeaderName, nameof(options.Value.OriginalHostHeaderName));
+            EnsureOptionNotNullorWhitespace(options.Value.OriginalProtoHeaderName, nameof(options.Value.OriginalProtoHeaderName));
+
+            _options = options.Value;
+            _logger = loggerFactory.CreateLogger<ForwardedHeadersForwarder>();
+        }
+
+        private static void EnsureOptionNotNullorWhitespace(string value, string propertyName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException($"options.{propertyName} is required", "options");
+            }
+        }
+
+        public override void ApplyForwarders(HttpContext context)
+        {
+            // Gather expected headers. Enabled headers must have the same number of entries.
+            string[] forwardedFor = null, forwardedProto = null, forwardedHost = null;
+            bool checkFor = false, checkProto = false, checkHost = false;
+            int entryCount = 0;
+
+            if ((_options.ForwardedHeaders & ForwardedHeaders.XForwardedFor) == ForwardedHeaders.XForwardedFor)
+            {
+                checkFor = true;
+                forwardedFor = context.Request.Headers.GetCommaSeparatedValues(_options.ForwardedForHeaderName);
+                entryCount = Math.Max(forwardedFor.Length, entryCount);
+            }
+
+            if ((_options.ForwardedHeaders & ForwardedHeaders.XForwardedProto) == ForwardedHeaders.XForwardedProto)
+            {
+                checkProto = true;
+                forwardedProto = context.Request.Headers.GetCommaSeparatedValues(_options.ForwardedProtoHeaderName);
+                if (_options.RequireHeaderSymmetry && checkFor && forwardedFor.Length != forwardedProto.Length)
+                {
+                    _logger.LogWarning(1, "Parameter count mismatch between X-Forwarded-For and X-Forwarded-Proto.");
+                    return;
+                }
+                entryCount = Math.Max(forwardedProto.Length, entryCount);
+            }
+
+            if ((_options.ForwardedHeaders & ForwardedHeaders.XForwardedHost) == ForwardedHeaders.XForwardedHost)
+            {
+                checkHost = true;
+                forwardedHost = context.Request.Headers.GetCommaSeparatedValues(_options.ForwardedHostHeaderName);
+                if (_options.RequireHeaderSymmetry
+                    && ((checkFor && forwardedFor.Length != forwardedHost.Length)
+                        || (checkProto && forwardedProto.Length != forwardedHost.Length)))
+                {
+                    _logger.LogWarning(1, "Parameter count mismatch between X-Forwarded-Host and X-Forwarded-For or X-Forwarded-Proto.");
+                    return;
+                }
+                entryCount =  Math.Max(forwardedHost.Length, entryCount);
+            }
+
+            // Apply ForwardLimit, if any
+            if (_options.ForwardLimit.HasValue && entryCount > _options.ForwardLimit)
+            {
+                entryCount = _options.ForwardLimit.Value;
+            }
+
+            // Group the data together.
+            var sets = new SetOfForwarders[entryCount];
+            for (int i = 0; i < sets.Length; i++)
+            {
+                // They get processed in reverse order, right to left.
+                var set = new SetOfForwarders();
+                if (checkFor && i < forwardedFor.Length)
+                {
+                    set.IpAndPortText = forwardedFor[forwardedFor.Length - i - 1];
+                }
+                if (checkProto && i < forwardedProto.Length)
+                {
+                    set.Scheme = forwardedProto[forwardedProto.Length - i - 1];
+                }
+                if (checkHost && i < forwardedHost.Length)
+                {
+                    set.Host = forwardedHost[forwardedHost.Length - i - 1];
+                }
+                sets[i] = set;
+            }
+
+            // Gather initial values
+            var connection = context.Connection;
+            var request = context.Request;
+            var currentValues = new SetOfForwarders()
+            {
+                RemoteIpAndPort = connection.RemoteIpAddress != null ? new IPEndPoint(connection.RemoteIpAddress, connection.RemotePort) : null,
+                // Host and Scheme initial values are never inspected, no need to set them here.
+            };
+
+            var checkKnownIps = _options.KnownNetworks.Count > 0 || _options.KnownProxies.Count > 0;
+            bool applyChanges = false;
+            int entriesConsumed = 0;
+
+            for ( ; entriesConsumed < sets.Length; entriesConsumed++)
+            {
+                var set = sets[entriesConsumed];
+                if (checkFor)
+                {
+                    // For the first instance, allow remoteIp to be null for servers that don't support it natively.
+                    if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
+                    {
+                        // Stop at the first unknown remote IP, but still apply changes processed so far.
+                        _logger.LogDebug(1, $"Unknown proxy: {currentValues.RemoteIpAndPort}");
+                        break;
+                    }
+
+                    IPEndPoint parsedEndPoint;
+                    if (IPEndPointParser.TryParse(set.IpAndPortText, out parsedEndPoint))
+                    {
+                        applyChanges = true;
+                        set.RemoteIpAndPort = parsedEndPoint;
+                        currentValues.IpAndPortText = set.IpAndPortText;
+                        currentValues.RemoteIpAndPort = set.RemoteIpAndPort;
+                    }
+                    else if (!string.IsNullOrEmpty(set.IpAndPortText))
+                    {
+                        // Stop at the first unparsable IP, but still apply changes processed so far.
+                        _logger.LogDebug(1, $"Unparsable IP: {set.IpAndPortText}");
+                        break;
+                    }
+                    else if (_options.RequireHeaderSymmetry)
+                    {
+                        _logger.LogWarning(2, $"Missing forwarded IPAddress.");
+                        return;
+                    }
+                }
+
+                if (checkProto)
+                {
+                    if (!string.IsNullOrEmpty(set.Scheme))
+                    {
+                        applyChanges = true;
+                        currentValues.Scheme = set.Scheme;
+                    }
+                    else if (_options.RequireHeaderSymmetry)
+                    {
+                        _logger.LogWarning(3, $"Forwarded scheme is not present, this is required by {nameof(_options.RequireHeaderSymmetry)}");
+                        return;
+                    }
+                }
+
+                if (checkHost)
+                {
+                    if (!string.IsNullOrEmpty(set.Host))
+                    {
+                        applyChanges = true;
+                        currentValues.Host = set.Host;
+                    }
+                    else if (_options.RequireHeaderSymmetry)
+                    {
+                        _logger.LogWarning(4, $"Incorrect number of x-forwarded-proto header values, see {nameof(_options.RequireHeaderSymmetry)}.");
+                        return;
+                    }
+                }
+            }
+
+            if (applyChanges)
+            {
+                if (checkFor && currentValues.RemoteIpAndPort != null)
+                {
+                    if (connection.RemoteIpAddress != null)
+                    {
+                        // Save the original
+                        request.Headers[_options.OriginalForHeaderName] = new IPEndPoint(connection.RemoteIpAddress, connection.RemotePort).ToString();
+                    }
+                    if (forwardedFor.Length > entriesConsumed)
+                    {
+                        // Truncate the consumed header values
+                        request.Headers[_options.ForwardedForHeaderName] = forwardedFor.Take(forwardedFor.Length - entriesConsumed).ToArray();
+                    }
+                    else
+                    {
+                        // All values were consumed
+                        request.Headers.Remove(_options.ForwardedForHeaderName);
+                    }
+                    connection.RemoteIpAddress = currentValues.RemoteIpAndPort.Address;
+                    connection.RemotePort = currentValues.RemoteIpAndPort.Port;
+                }
+
+                if (checkProto && currentValues.Scheme != null)
+                {
+                    // Save the original
+                    request.Headers[_options.OriginalProtoHeaderName] = request.Scheme;
+                    if (forwardedProto.Length > entriesConsumed)
+                    {
+                        // Truncate the consumed header values
+                        request.Headers[_options.ForwardedProtoHeaderName] = forwardedProto.Take(forwardedProto.Length - entriesConsumed).ToArray();
+                    }
+                    else
+                    {
+                        // All values were consumed
+                        request.Headers.Remove(_options.ForwardedProtoHeaderName);
+                    }
+                    request.Scheme = currentValues.Scheme;
+                }
+
+                if (checkHost && currentValues.Host != null)
+                {
+                    // Save the original
+                    request.Headers[_options.OriginalHostHeaderName] = request.Host.ToString();
+                    if (forwardedHost.Length > entriesConsumed)
+                    {
+                        // Truncate the consumed header values
+                        request.Headers[_options.ForwardedHostHeaderName] = forwardedHost.Take(forwardedHost.Length - entriesConsumed).ToArray();
+                    }
+                    else
+                    {
+                        // All values were consumed
+                        request.Headers.Remove(_options.ForwardedHostHeaderName);
+                    }
+                    request.Host = HostString.FromUriComponent(currentValues.Host);
+                }
+            }
+        }
+
+        private bool CheckKnownAddress(IPAddress address)
+        {
+            if (_options.KnownProxies.Contains(address))
+            {
+                return true;
+            }
+            foreach (var network in _options.KnownNetworks)
+            {
+                if (network.Contains(address))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private struct SetOfForwarders
+        {
+            public string IpAndPortText;
+            public IPEndPoint RemoteIpAndPort;
+            public string Host;
+            public string Scheme;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersMiddleware.cs
@@ -2,16 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.HttpOverrides.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.HttpOverrides
 {
@@ -19,7 +14,7 @@ namespace Microsoft.AspNetCore.HttpOverrides
     {
         private readonly ForwardedHeadersOptions _options;
         private readonly RequestDelegate _next;
-        private readonly ILogger _logger;
+        private readonly ForwardedHeadersForwarder _forwardedHeadersForwarder;
 
         public ForwardedHeadersMiddleware(RequestDelegate next, ILoggerFactory loggerFactory, IOptions<ForwardedHeadersOptions> options)
         {
@@ -35,26 +30,9 @@ namespace Microsoft.AspNetCore.HttpOverrides
             {
                 throw new ArgumentNullException(nameof(options));
             }
-
-            // Make sure required options is not null or whitespace
-            EnsureOptionNotNullorWhitespace(options.Value.ForwardedForHeaderName, nameof(options.Value.ForwardedForHeaderName));
-            EnsureOptionNotNullorWhitespace(options.Value.ForwardedHostHeaderName, nameof(options.Value.ForwardedHostHeaderName));
-            EnsureOptionNotNullorWhitespace(options.Value.ForwardedProtoHeaderName, nameof(options.Value.ForwardedProtoHeaderName));
-            EnsureOptionNotNullorWhitespace(options.Value.OriginalForHeaderName, nameof(options.Value.OriginalForHeaderName));
-            EnsureOptionNotNullorWhitespace(options.Value.OriginalHostHeaderName, nameof(options.Value.OriginalHostHeaderName));
-            EnsureOptionNotNullorWhitespace(options.Value.OriginalProtoHeaderName, nameof(options.Value.OriginalProtoHeaderName));
-
             _options = options.Value;
-            _logger = loggerFactory.CreateLogger<ForwardedHeadersMiddleware>();
             _next = next;
-        }
-
-        private static void EnsureOptionNotNullorWhitespace(string value, string propertyName)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                throw new ArgumentException($"options.{propertyName} is required", "options");
-            }
+            _forwardedHeadersForwarder = new ForwardedHeadersForwarder(loggerFactory, options);
         }
 
         public Task Invoke(HttpContext context)
@@ -63,230 +41,15 @@ namespace Microsoft.AspNetCore.HttpOverrides
             return _next(context);
         }
 
-        public void ApplyForwarders(HttpContext context)
+		public void ApplyForwarders(HttpContext context)
         {
-            // Gather expected headers. Enabled headers must have the same number of entries.
-            string[] forwardedFor = null, forwardedProto = null, forwardedHost = null;
-            bool checkFor = false, checkProto = false, checkHost = false;
-            int entryCount = 0;
+            // apply forwareded headers forwarder
+            _forwardedHeadersForwarder.ApplyForwarders(context);
 
-            if ((_options.ForwardedHeaders & ForwardedHeaders.XForwardedFor) == ForwardedHeaders.XForwardedFor)
-            {
-                checkFor = true;
-                forwardedFor = context.Request.Headers.GetCommaSeparatedValues(_options.ForwardedForHeaderName);
-                entryCount = Math.Max(forwardedFor.Length, entryCount);
-            }
-
-            if ((_options.ForwardedHeaders & ForwardedHeaders.XForwardedProto) == ForwardedHeaders.XForwardedProto)
-            {
-                checkProto = true;
-                forwardedProto = context.Request.Headers.GetCommaSeparatedValues(_options.ForwardedProtoHeaderName);
-                if (_options.RequireHeaderSymmetry && checkFor && forwardedFor.Length != forwardedProto.Length)
-                {
-                    _logger.LogWarning(1, "Parameter count mismatch between X-Forwarded-For and X-Forwarded-Proto.");
-                    return;
-                }
-                entryCount = Math.Max(forwardedProto.Length, entryCount);
-            }
-
-            if ((_options.ForwardedHeaders & ForwardedHeaders.XForwardedHost) == ForwardedHeaders.XForwardedHost)
-            {
-                checkHost = true;
-                forwardedHost = context.Request.Headers.GetCommaSeparatedValues(_options.ForwardedHostHeaderName);
-                if (_options.RequireHeaderSymmetry
-                    && ((checkFor && forwardedFor.Length != forwardedHost.Length)
-                        || (checkProto && forwardedProto.Length != forwardedHost.Length)))
-                {
-                    _logger.LogWarning(1, "Parameter count mismatch between X-Forwarded-Host and X-Forwarded-For or X-Forwarded-Proto.");
-                    return;
-                }
-                entryCount =  Math.Max(forwardedHost.Length, entryCount);
-            }
-
-            // Apply ForwardLimit, if any
-            if (_options.ForwardLimit.HasValue && entryCount > _options.ForwardLimit)
-            {
-                entryCount = _options.ForwardLimit.Value;
-            }
-
-            // Group the data together.
-            var sets = new SetOfForwarders[entryCount];
-            for (int i = 0; i < sets.Length; i++)
-            {
-                // They get processed in reverse order, right to left.
-                var set = new SetOfForwarders();
-                if (checkFor && i < forwardedFor.Length)
-                {
-                    set.IpAndPortText = forwardedFor[forwardedFor.Length - i - 1];
-                }
-                if (checkProto && i < forwardedProto.Length)
-                {
-                    set.Scheme = forwardedProto[forwardedProto.Length - i - 1];
-                }
-                if (checkHost && i < forwardedHost.Length)
-                {
-                    set.Host = forwardedHost[forwardedHost.Length - i - 1];
-                }
-                sets[i] = set;
-            }
-
-            // Gather initial values
-            var connection = context.Connection;
-            var request = context.Request;
-            var currentValues = new SetOfForwarders()
-            {
-                RemoteIpAndPort = connection.RemoteIpAddress != null ? new IPEndPoint(connection.RemoteIpAddress, connection.RemotePort) : null,
-                // Host and Scheme initial values are never inspected, no need to set them here.
-            };
-
-            var checkKnownIps = _options.KnownNetworks.Count > 0 || _options.KnownProxies.Count > 0;
-            bool applyChanges = false;
-            int entriesConsumed = 0;
-
-            for ( ; entriesConsumed < sets.Length; entriesConsumed++)
-            {
-                var set = sets[entriesConsumed];
-                if (checkFor)
-                {
-                    // For the first instance, allow remoteIp to be null for servers that don't support it natively.
-                    if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
-                    {
-                        // Stop at the first unknown remote IP, but still apply changes processed so far.
-                        _logger.LogDebug(1, $"Unknown proxy: {currentValues.RemoteIpAndPort}");
-                        break;
-                    }
-
-                    IPEndPoint parsedEndPoint;
-                    if (IPEndPointParser.TryParse(set.IpAndPortText, out parsedEndPoint))
-                    {
-                        applyChanges = true;
-                        set.RemoteIpAndPort = parsedEndPoint;
-                        currentValues.IpAndPortText = set.IpAndPortText;
-                        currentValues.RemoteIpAndPort = set.RemoteIpAndPort;
-                    }
-                    else if (!string.IsNullOrEmpty(set.IpAndPortText))
-                    {
-                        // Stop at the first unparsable IP, but still apply changes processed so far.
-                        _logger.LogDebug(1, $"Unparsable IP: {set.IpAndPortText}");
-                        break;
-                    }
-                    else if (_options.RequireHeaderSymmetry)
-                    {
-                        _logger.LogWarning(2, $"Missing forwarded IPAddress.");
-                        return;
-                    }
-                }
-
-                if (checkProto)
-                {
-                    if (!string.IsNullOrEmpty(set.Scheme))
-                    {
-                        applyChanges = true;
-                        currentValues.Scheme = set.Scheme;
-                    }
-                    else if (_options.RequireHeaderSymmetry)
-                    {
-                        _logger.LogWarning(3, $"Forwarded scheme is not present, this is required by {nameof(_options.RequireHeaderSymmetry)}");
-                        return;
-                    }
-                }
-
-                if (checkHost)
-                {
-                    if (!string.IsNullOrEmpty(set.Host))
-                    {
-                        applyChanges = true;
-                        currentValues.Host = set.Host;
-                    }
-                    else if (_options.RequireHeaderSymmetry)
-                    {
-                        _logger.LogWarning(4, $"Incorrect number of x-forwarded-proto header values, see {nameof(_options.RequireHeaderSymmetry)}.");
-                        return;
-                    }
-                }
-            }
-
-            if (applyChanges)
-            {
-                if (checkFor && currentValues.RemoteIpAndPort != null)
-                {
-                    if (connection.RemoteIpAddress != null)
-                    {
-                        // Save the original
-                        request.Headers[_options.OriginalForHeaderName] = new IPEndPoint(connection.RemoteIpAddress, connection.RemotePort).ToString();
-                    }
-                    if (forwardedFor.Length > entriesConsumed)
-                    {
-                        // Truncate the consumed header values
-                        request.Headers[_options.ForwardedForHeaderName] = forwardedFor.Take(forwardedFor.Length - entriesConsumed).ToArray();
-                    }
-                    else
-                    {
-                        // All values were consumed
-                        request.Headers.Remove(_options.ForwardedForHeaderName);
-                    }
-                    connection.RemoteIpAddress = currentValues.RemoteIpAndPort.Address;
-                    connection.RemotePort = currentValues.RemoteIpAndPort.Port;
-                }
-
-                if (checkProto && currentValues.Scheme != null)
-                {
-                    // Save the original
-                    request.Headers[_options.OriginalProtoHeaderName] = request.Scheme;
-                    if (forwardedProto.Length > entriesConsumed)
-                    {
-                        // Truncate the consumed header values
-                        request.Headers[_options.ForwardedProtoHeaderName] = forwardedProto.Take(forwardedProto.Length - entriesConsumed).ToArray();
-                    }
-                    else
-                    {
-                        // All values were consumed
-                        request.Headers.Remove(_options.ForwardedProtoHeaderName);
-                    }
-                    request.Scheme = currentValues.Scheme;
-                }
-
-                if (checkHost && currentValues.Host != null)
-                {
-                    // Save the original
-                    request.Headers[_options.OriginalHostHeaderName] = request.Host.ToString();
-                    if (forwardedHost.Length > entriesConsumed)
-                    {
-                        // Truncate the consumed header values
-                        request.Headers[_options.ForwardedHostHeaderName] = forwardedHost.Take(forwardedHost.Length - entriesConsumed).ToArray();
-                    }
-                    else
-                    {
-                        // All values were consumed
-                        request.Headers.Remove(_options.ForwardedHostHeaderName);
-                    }
-                    request.Host = HostString.FromUriComponent(currentValues.Host);
-                }
-            }
-        }
-
-        private bool CheckKnownAddress(IPAddress address)
-        {
-            if (_options.KnownProxies.Contains(address))
-            {
-                return true;
-            }
-            foreach (var network in _options.KnownNetworks)
-            {
-                if (network.Contains(address))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private struct SetOfForwarders
-        {
-            public string IpAndPortText;
-            public IPEndPoint RemoteIpAndPort;
-            public string Host;
-            public string Scheme;
+            // apply additional fowarders
+            if (_options.AdditionalForwarders != null)
+                foreach (var forwarder in _options.AdditionalForwarders)
+                    forwarder.ApplyForwarders(context);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersOptions.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersOptions.cs
@@ -72,5 +72,8 @@ namespace Microsoft.AspNetCore.Builder
         /// The default is 'false'.
         /// </summary>
         public bool RequireHeaderSymmetry { get; set; } = false;
+
+        // Additional Forwarders
+        public IEnumerable<Forwarder> AdditionalForwarders { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.HttpOverrides/Forwarder.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/Forwarder.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public abstract class Forwarder
+    {
+        public abstract void ApplyForwarders(HttpContext context);
+    }
+}

--- a/test/Microsoft.AspNetCore.HttpOverrides.Tests/ForwardedHeadersMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.HttpOverrides.Tests/ForwardedHeadersMiddlewareTest.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides.Tests;
 using Microsoft.AspNetCore.TestHost;
 using Xunit;
 
@@ -579,5 +581,102 @@ namespace Microsoft.AspNetCore.HttpOverrides
             await server.CreateClient().SendAsync(req);
             Assert.True(assertsExecuted);
         }
-    }
+
+	    [Fact]
+	    public async Task ForwarderNewForwarder()
+	    {
+		    var assertsExecuted = false;
+
+		    var builder = new WebHostBuilder()
+			    .Configure(app =>
+			    {
+				    app.UseForwardedHeaders(new ForwardedHeadersOptions()
+				    {
+					    AdditionalForwarders = new List<Forwarder> { new TestForwarder() }
+				    });
+				    app.Run(context =>
+				    {
+					    Assert.Equal("https", context.Request.Scheme);
+					    assertsExecuted = true;
+					    return Task.FromResult(0);
+				    });
+			    });
+		    var server = new TestServer(builder);
+
+		    var req = new HttpRequestMessage(HttpMethod.Get, "");
+		    req.Headers.Add("X-ARR-SSL", "something");
+		    await server.CreateClient().SendAsync(req);
+		    Assert.True(assertsExecuted);
+	    }
+
+	    [Fact]
+	    public async Task ForwarderForwardedHeadersForwarder()
+	    {
+		    var assertsExecuted = false;
+
+		    var builder = new WebHostBuilder()
+			    .Configure(app =>
+			    {
+				    app.UseForwardedHeaders(new ForwardedHeadersOptions
+				    {
+					    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+					    AdditionalForwarders = new List<Forwarder> { }
+				    });
+				    app.Run(context =>
+				    {
+					    Assert.Equal("11.111.111.11", context.Connection.RemoteIpAddress.ToString());
+					    Assert.Equal("localhost", context.Request.Host.ToString());
+					    Assert.Equal("Protocol", context.Request.Scheme);
+					    assertsExecuted = true;
+					    return Task.FromResult(0);
+
+				    });
+			    });
+		    var server = new TestServer(builder);
+
+		    var req = new HttpRequestMessage(HttpMethod.Get, "");
+		    req.Headers.Add("X-Forwarded-For", "11.111.111.11");
+		    req.Headers.Add("X-Forwarded-Proto", "Protocol");
+		    await server.CreateClient().SendAsync(req);
+		    Assert.True(assertsExecuted);
+	    }
+
+	    [Fact]
+	    public async Task ForwarderCombineForwardedHeadersForwarderAndNewForwarder()
+	    {
+		    var assertsExecuted = false;
+
+		    var builder = new WebHostBuilder()
+			    .Configure(app =>
+			    {
+				    var options = new ForwardedHeadersOptions
+				    {
+					    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+
+					    AdditionalForwarders = new List<Forwarder>
+					    {
+						    new TestForwarder()
+					    }
+				    };
+				    app.UseForwardedHeaders(options);
+				    app.Run(context =>
+				    {
+					    Assert.Equal("11.111.111.11", context.Connection.RemoteIpAddress.ToString());
+					    Assert.Equal("localhost", context.Request.Host.ToString());
+					    Assert.Equal("https", context.Request.Scheme);
+					    assertsExecuted = true;
+					    return Task.FromResult(0);
+
+				    });
+			    });
+		    var server = new TestServer(builder);
+
+		    var req = new HttpRequestMessage(HttpMethod.Get, "");
+		    req.Headers.Add("X-Forwarded-For", "11.111.111.11");
+		    req.Headers.Add("X-Forwarded-Proto", "Protocol");
+		    req.Headers.Add("X-ARR-SSL", "something");
+		    await server.CreateClient().SendAsync(req);
+		    Assert.True(assertsExecuted);
+	    }
+	}
 }

--- a/test/Microsoft.AspNetCore.HttpOverrides.Tests/TestForwarder.cs
+++ b/test/Microsoft.AspNetCore.HttpOverrides.Tests/TestForwarder.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.HttpOverrides.Tests
+{
+    public class TestForwarder : Forwarder
+    {
+	    public override void ApplyForwarders(HttpContext context)
+	    {
+		    if (!context.Request.Headers.ContainsKey("X-ARR-SSL")) return;
+				context.Request.Scheme = "https";
+				context.Request.Headers.Remove("X-ARR-SSL");
+	    }
+    }
+}


### PR DESCRIPTION
**Problem**: Not all webservers seem to use the default ForwardedHeaders (X-Forwarded-For, X-Forwarded-Host and X-Forwarded-Proto) but use their own headers. 

**Example**: Azure doesn't the X-Forwarded-Proto header when SSL is used but you need to check the content of X-ARR-SSL to see if https is used.

By making it possible to add additional forwarders to the ForwardedHeadersMiddleware you can use this Middleware for all webservers without the need to create your own custom middleware to catch the webserver that have their own headers.




