### PR TITLE
Normalize VersionPrefix

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
+    <AspNetCoreVersion>2.1.0-*</AspNetCoreVersion>
     <InternalAspNetCoreSdkVersion>2.0.1-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.49</MoqVersion>
     <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>

--- a/src/Microsoft.AspNetCore.Buffering/Microsoft.AspNetCore.Buffering.csproj
+++ b/src/Microsoft.AspNetCore.Buffering/Microsoft.AspNetCore.Buffering.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <Description>ASP.NET Core middleware for buffering response bodies.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Microsoft.AspNetCore.HttpOverrides/Microsoft.AspNetCore.HttpOverrides.csproj
+++ b/src/Microsoft.AspNetCore.HttpOverrides/Microsoft.AspNetCore.HttpOverrides.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <Description>ASP.NET Core basic middleware for supporting HTTP method overrides. Includes:
 * X-Forwarded-* headers to forward headers from a proxy.
 * HTTP method override header.</Description>

--- a/src/Microsoft.AspNetCore.ResponseCompression/Microsoft.AspNetCore.ResponseCompression.csproj
+++ b/src/Microsoft.AspNetCore.ResponseCompression/Microsoft.AspNetCore.ResponseCompression.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <Description>ASP.NET Core middleware for HTTP Response compression.</Description>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Microsoft.AspNetCore.Rewrite/Microsoft.AspNetCore.Rewrite.csproj
+++ b/src/Microsoft.AspNetCore.Rewrite/Microsoft.AspNetCore.Rewrite.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <Description>ASP.NET Core basic middleware for rewriting URLs. Includes:
 * Support for custom URL rewrite rules
 * Support for running IIS URL Rewrite module rules

--- a/version.props
+++ b/version.props
@@ -1,6 +1,7 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
   <PropertyGroup>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix>preview1</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Leaving the version of Microsoft.AspNetCore.Buffering alone as I assume there's a reason it's 0.3.0 and not 2.0.0.