### PR TITLE
Consume new CreateHttpContext test pattern

### DIFF
--- a/test/Microsoft.AspNetCore.HttpsEnforcement.Tests/HstsMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.HttpsEnforcement.Tests/HstsMiddlewareTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
         public async Task SetOptionsWithDefault_SetsMaxAgeToCorrectValue()
         {
             var builder = new WebHostBuilder()
-                .UseUrls("https://*:5050")
                 .ConfigureServices(services =>
                 {
                 })
@@ -57,7 +56,6 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
         public async Task SetOptionsThroughConfigure_SetsHeaderCorrectly(int maxAge, bool includeSubDomains, bool preload, string expected)
         {
             var builder = new WebHostBuilder()
-                .UseUrls("https://*:5050")
                 .ConfigureServices(services =>
                 {
                     services.Configure<HstsOptions>(options => {
@@ -96,7 +94,6 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
         public async Task SetOptionsThroughHelper_SetsHeaderCorrectly(int maxAge, bool includeSubDomains, bool preload, string expected)
         {
             var builder = new WebHostBuilder()
-                .UseUrls("https://*:5050")
                 .ConfigureServices(services =>
                 {
                     services.AddHsts(options => {

--- a/test/Microsoft.AspNetCore.HttpsEnforcement.Tests/HttpsPolicyTests.cs
+++ b/test/Microsoft.AspNetCore.HttpsEnforcement.Tests/HttpsPolicyTests.cs
@@ -30,7 +30,6 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
         {
 
             var builder = new WebHostBuilder()
-                .UseUrls("https://*:5050", "http://*:5050")
                 .ConfigureServices(services =>
                 {
                     services.Configure<HttpsRedirectionOptions>(options =>


### PR DESCRIPTION
Test updates only. This demonstrates the new TestServer capabilities from https://github.com/aspnet/Hosting/pull/1248.