### PR TITLE
Add image/svg+xml MIME type to be compressed

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionDefaults.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionDefaults.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             "text/xml",
             "application/json",
             "text/json",
+	        "image/svg+xml"
         };
     }
 }


### PR DESCRIPTION
Your default MIME types to compress list is pretty comprehensive but it's missing the SVG mime type which is ultimately XML.

Even the example posted about adding Brotli support adds it:

https://blogs.msdn.microsoft.com/dotnet/2017/07/27/introducing-support-for-brotli-compression/