### PR TITLE
Read from IServerAddressesFeature for HTTPS port

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,25 +3,25 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
-    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15576</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
-    <MicrosoftAspNetCoreHttpPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHttpPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelCorePackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreServerKestrelCorePackageVersion>
-    <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreServerKestrelPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreTestHostPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsConfigurationBinderPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsLoggingTestingPackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsOptionsPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15638</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
+    <MicrosoftAspNetCoreHttpPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreHttpPackageVersion>
+    <MicrosoftAspNetCoreServerKestrelCorePackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreServerKestrelCorePackageVersion>
+    <MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>
+    <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreServerKestrelPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview1-27855</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview1-27855</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview1-27855</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.1.0-preview1-27855</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview1-27855</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27855</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27855</MicrosoftExtensionsLoggingTestingPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview1-27855</MicrosoftExtensionsOptionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview1-26016-05</MicrosoftNETCoreApp21PackageVersion>
-    <MicrosoftNetHttpHeadersPackageVersion>2.1.0-preview1-27849</MicrosoftNetHttpHeadersPackageVersion>
+    <MicrosoftNetHttpHeadersPackageVersion>2.1.0-preview1-27855</MicrosoftNetHttpHeadersPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <XunitAnalyzersPackageVersion>0.8.0</XunitAnalyzersPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -13,6 +13,7 @@
     <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreServerKestrelPackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsConfigurationBinderPackageVersion>
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsLoggingConsolePackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,20 +3,21 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
-    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15626</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
-    <MicrosoftAspNetCoreHttpPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreHttpPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreServerKestrelPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreTestHostPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingTestingPackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsOptionsPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15576</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
+    <MicrosoftAspNetCoreHttpPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHttpPackageVersion>
+    <MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>
+    <MicrosoftAspNetCoreServerKestrelCorePackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreServerKestrelCorePackageVersion>
+    <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreServerKestrelPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsLoggingTestingPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsOptionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview1-26016-05</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNetHttpHeadersPackageVersion>2.1.0-preview1-27849</MicrosoftNetHttpHeadersPackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview1-15626
-commithash:fd6410e9c90c428bc01238372303ad09cb9ec889
+version:2.1.0-preview1-15638
+commithash:1d3a0c725dc6b8ae6b0e47800fd6b4d8f8b8d545

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionBuilderExtensions.cs
@@ -38,19 +38,16 @@ namespace Microsoft.AspNetCore.Builder
             // 2. HTTPS_PORT environment variable
             // 3. IServerAddressesFeature
             // 4. 443 (or not set.)
-
-
             var httpsPort = 0;
             if (options.HttpsPort == null)
             {
-                if (TryGetHttpsPortFromEnvironmentVariable(app, out httpsPort)
-                    || TryGetHttpsPortFromIServerAddressesFeature(app, out httpsPort))
+                if (TryGetHttpsPortFromEnvironmentVariable(app, out httpsPort))
                 {
                     options.HttpsPort = httpsPort;
                 }
             }
 
-            app.UseMiddleware<HttpsRedirectionMiddleware>();
+            app.UseMiddleware<HttpsRedirectionMiddleware>(app.ServerFeatures.Get<IServerAddressesFeature>());
 
             return app;
         }
@@ -68,14 +65,5 @@ namespace Microsoft.AspNetCore.Builder
             return false;
         }
 
-        private static bool TryGetHttpsPortFromIServerAddressesFeature(IApplicationBuilder app, out int httpsPort)
-        {
-            httpsPort = 0;
-            var addressFeature = app.ServerFeatures.Get<IServerAddressesFeature>();
-            foreach (var address in addressFeature.Addresses)
-            {
-            }
-            return false;
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionBuilderExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -32,25 +31,9 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             var options = app.ApplicationServices.GetRequiredService<IOptions<HttpsRedirectionOptions>>().Value;
+            var config = app.ApplicationServices.GetRequiredService<IConfiguration>();
 
-            // Order for finding the HTTPS port:
-            // 1. Set in the HttpsRedirectionOptions
-            // 2. HTTPS_PORT environment variable
-            // 3. IServerAddressesFeature (checked in HttpsRedirectionMiddleware.Invoke
-            // 4. 443 (or not set)
-            if (options.HttpsPort == null)
-            {
-                var config = app.ApplicationServices.GetRequiredService<IConfiguration>();
-                var configHttpsPort = config["HTTPS_PORT"];
-                // If the string isn't empty, try to parse it.
-                if (!string.IsNullOrEmpty(configHttpsPort)
-                                    && int.TryParse(configHttpsPort, out var intHttpsPort))
-                {
-                        options.HttpsPort = intHttpsPort;
-                }
-            }
-
-            app.UseMiddleware<HttpsRedirectionMiddleware>(app.ServerFeatures.Get<IServerAddressesFeature>());
+            app.UseMiddleware<HttpsRedirectionMiddleware>(app.ServerFeatures.Get<IServerAddressesFeature>(), config);
 
             return app;
         }

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionBuilderExtensions.cs
@@ -38,19 +38,15 @@ namespace Microsoft.AspNetCore.Builder
             // 2. HTTPS_PORT environment variable
             // 3. IServerAddressesFeature (checked in HttpsRedirectionMiddleware.Invoke
             // 4. 443 (or not set)
-            var httpsPort = 0;
             if (options.HttpsPort == null)
             {
-                httpsPort = 0;
                 var config = app.ApplicationServices.GetRequiredService<IConfiguration>();
                 var configHttpsPort = config["HTTPS_PORT"];
                 // If the string isn't empty, try to parse it.
-                if (!string.IsNullOrEmpty(configHttpsPort))
+                if (!string.IsNullOrEmpty(configHttpsPort)
+                                    && int.TryParse(configHttpsPort, out var intHttpsPort))
                 {
-                    if (int.TryParse(configHttpsPort, out httpsPort))
-                    {
-                        options.HttpsPort = httpsPort;
-                    }
+                        options.HttpsPort = intHttpsPort;
                 }
             }
 

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionBuilderExtensions.cs
@@ -31,9 +31,8 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             var options = app.ApplicationServices.GetRequiredService<IOptions<HttpsRedirectionOptions>>().Value;
-            var config = app.ApplicationServices.GetRequiredService<IConfiguration>();
 
-            app.UseMiddleware<HttpsRedirectionMiddleware>(app.ServerFeatures.Get<IServerAddressesFeature>(), config);
+            app.UseMiddleware<HttpsRedirectionMiddleware>(app.ServerFeatures.Get<IServerAddressesFeature>());
 
             return app;
         }

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
@@ -94,10 +94,9 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             // 3. IServerAddressesFeature
             // 4. 443 (or not set)
 
-            var configHttpsPort = _config.GetValue<int?>("HTTPS_PORT");
-            if (configHttpsPort.HasValue)
+            _httpsPort = _config.GetValue<int?>("HTTPS_PORT");
+            if (_httpsPort.HasValue)
             {
-                _httpsPort = configHttpsPort;
                 return;
             } 
 
@@ -105,13 +104,13 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             foreach (var address in _serverAddressesFeature.Addresses)
             {
                 var bindingAddress = BindingAddress.Parse(address);
-                if (bindingAddress.Scheme == "https")
+                if (bindingAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
                 {
                     // If we find multiple different https ports specified, throw
-                    if (httpsPort != null && httpsPort != bindingAddress.Port)
+                    if (httpsPort.HasValue && httpsPort != bindingAddress.Port)
                     {
-                        throw new ArgumentException($"Cannot specify multiple https ports in IServerAddressesFeature. " +
-                            $"Conflict found with ports: {httpsPort.Value}, {bindingAddress.Port}.");
+                        throw new ArgumentException("Cannot determine the https port from IServerAddressesFeature, multiple values were found. " +
+                            "Please set the desired port explicitly on HttpsRedirectionOptions.HttpsPort.");
                     }
                     else
                     {

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             int? httpsPort = null;
             foreach (var address in _serverAddressesFeature.Addresses)
             {
-                var serverAddress = ServerAddress.FromUrl(address);
+                var serverAddress = BindingAddress;
                 if (serverAddress.Scheme == "https")
                 {
                     // If we find multiple different https ports specified, throw

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Options;
@@ -15,9 +16,11 @@ namespace Microsoft.AspNetCore.HttpsPolicy
     public class HttpsRedirectionMiddleware
     {
         private readonly RequestDelegate _next;
-        private readonly int? _httpsPort;
+        private int? _httpsPort;
         private readonly int _statusCode;
-        public HttpsRedirectionMiddleware(RequestDelegate next, IOptions<HttpsRedirectionOptions> options)
+        private readonly IServerAddressesFeature _serverAddressesFeature;
+        private bool _evaluatedServerAddressesFeature;
+        public HttpsRedirectionMiddleware(RequestDelegate next, IOptions<HttpsRedirectionOptions> options, IServerAddressesFeature serverAddressesFeature)
         {
             if (next == null)
             {
@@ -31,30 +34,21 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             _next = next;
 
             var httpsRedirectionOptions = options.Value;
-
-            // The tls port set in options will have priority over the one in configuration.
-            var httpsPort = httpsRedirectionOptions.HttpsPort;
-            if (httpsPort == null)
-            {
-                // Only read configuration if there is no httpsPort
-                var config = app.ApplicationServices.GetRequiredService<IConfiguration>();
-                var configHttpsPort = config["HTTPS_PORT"];
-                // If the string isn't empty, try to parse it.
-                if (!string.IsNullOrEmpty(configHttpsPort)
-                    && int.TryParse(configHttpsPort, out var intHttpsPort))
-                {
-                    httpsPort = intHttpsPort;
-                }
-            }
-
             _httpsPort = httpsRedirectionOptions.HttpsPort;
             _statusCode = httpsRedirectionOptions.RedirectStatusCode;
+            _serverAddressesFeature = serverAddressesFeature;
         }
 
         public Task Invoke(HttpContext context)
         {
             if (!context.Request.IsHttps)
             {
+                if (!_evaluatedServerAddressesFeature)
+                {
+                    CheckAddressesFeatureForHttpsPorts();
+                }
+                _evaluatedServerAddressesFeature = true;
+
                 var host = context.Request.Host;
                 if (_httpsPort.HasValue && _httpsPort.Value > 0)
                 {
@@ -66,17 +60,37 @@ namespace Microsoft.AspNetCore.HttpsPolicy
                 }
 
                 var request = context.Request;
-                var newUrl = UriHelper.BuildAbsolute("https://", 
+                var newUrl = UriHelper.BuildAbsolute("https", 
                                                         host,
                                                         request.PathBase,
                                                         request.Path,
                                                         request.QueryString);
 
                 context.Response.StatusCode = _statusCode;
-                context.Response.Headers[HeaderNames.Location] = newUrl.ToString();
+                context.Response.Headers[HeaderNames.Location] = newUrl;
+                return Task.CompletedTask;
             }
 
             return _next(context);
+        }
+
+        private void CheckAddressesFeatureForHttpsPorts()
+        {
+            if (_serverAddressesFeature == null || _serverAddressesFeature.Addresses == null)
+            {
+                return;
+            }
+            foreach (var address in _serverAddressesFeature.Addresses)
+            {
+                if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
+                {
+                    if (uri.Scheme == "https")
+                    {
+                        _httpsPort = uri.Port;
+                        return;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.HttpsPolicy
+{
+    public class HttpsRedirectionMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly int? _httpsPort;
+        private readonly int _statusCode;
+        public HttpsRedirectionMiddleware(RequestDelegate next, IOptions<HttpsRedirectionOptions> options)
+        {
+            if (next == null)
+            {
+                throw new ArgumentNullException(nameof(next));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            _next = next;
+
+            var httpsRedirectionOptions = options.Value;
+
+            // The tls port set in options will have priority over the one in configuration.
+            var httpsPort = httpsRedirectionOptions.HttpsPort;
+            if (httpsPort == null)
+            {
+                // Only read configuration if there is no httpsPort
+                var config = app.ApplicationServices.GetRequiredService<IConfiguration>();
+                var configHttpsPort = config["HTTPS_PORT"];
+                // If the string isn't empty, try to parse it.
+                if (!string.IsNullOrEmpty(configHttpsPort)
+                    && int.TryParse(configHttpsPort, out var intHttpsPort))
+                {
+                    httpsPort = intHttpsPort;
+                }
+            }
+
+            _httpsPort = httpsRedirectionOptions.HttpsPort;
+            _statusCode = httpsRedirectionOptions.RedirectStatusCode;
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+            if (!context.Request.IsHttps)
+            {
+                var host = context.Request.Host;
+                if (_httpsPort.HasValue && _httpsPort.Value > 0)
+                {
+                    host = new HostString(host.Host, _httpsPort.Value);
+                }
+                else
+                {
+                    host = new HostString(host.Host);
+                }
+
+                var request = context.Request;
+                var newUrl = UriHelper.BuildAbsolute("https://", 
+                                                        host,
+                                                        request.PathBase,
+                                                        request.Path,
+                                                        request.QueryString);
+
+                context.Response.StatusCode = _statusCode;
+                context.Response.Headers[HeaderNames.Location] = newUrl.ToString();
+            }
+
+            return _next(context);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
@@ -104,18 +104,18 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             int? httpsPort = null;
             foreach (var address in _serverAddressesFeature.Addresses)
             {
-                var serverAddress = BindingAddress;
-                if (serverAddress.Scheme == "https")
+                var bindingAddress = BindingAddress.Parse(address);
+                if (bindingAddress.Scheme == "https")
                 {
                     // If we find multiple different https ports specified, throw
-                    if (httpsPort != null && httpsPort != serverAddress.Port)
+                    if (httpsPort != null && httpsPort != bindingAddress.Port)
                     {
                         throw new ArgumentException($"Cannot specify multiple https ports in IServerAddressesFeature. " +
-                            $"Conflict found with ports: {httpsPort.Value}, {serverAddress.Port}.");
+                            $"Conflict found with ports: {httpsPort.Value}, {bindingAddress.Port}.");
                     }
                     else
                     {
-                        httpsPort = serverAddress.Port;
+                        httpsPort = bindingAddress.Port;
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionMiddleware.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy
 
             if (!_evaluatedServerAddressesFeature && !_httpsPort.HasValue)
             {
-                CheckAddressesFeatureForHttpsPorts();
+                CheckForHttpsPorts();
             }
             _evaluatedServerAddressesFeature = true;
 
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             return Task.CompletedTask;
         }
 
-        private void CheckAddressesFeatureForHttpsPorts()
+        private void CheckForHttpsPorts()
         {
             // The IServerAddressesFeature will not be ready until the middleware is Invoked,
             // Order for finding the HTTPS port:
@@ -95,6 +95,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             // 2. HTTPS_PORT environment variable
             // 3. IServerAddressesFeature (checked in HttpsRedirectionMiddleware.Invoke
             // 4. 443 (or not set)
+
             if (_httpsPort != null)
             {
                 return;

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionOptions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionOptions.cs
@@ -18,6 +18,12 @@ namespace Microsoft.AspNetCore.HttpsPolicy
         /// <summary>
         /// The HTTPS port to be added to the redirected URL.
         /// </summary>
+        /// <remarks>
+        /// If the HttpsPort is not set, we will try to get the HttpsPort from the following:
+        /// 1. HTTPS_PORT environment variable
+        /// 2. IServerAddressesFeature
+        /// 3. 443 (or not set) 
+        /// </remarks>
         public int? HttpsPort { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionOptions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionOptions.cs
@@ -16,11 +16,8 @@ namespace Microsoft.AspNetCore.HttpsPolicy
         public int RedirectStatusCode { get; set; } = StatusCodes.Status302Found;
 
         /// <summary>
-        /// The TLS port to be added to the redirected URL.
+        /// The HTTPS port to be added to the redirected URL.
         /// </summary>
-        /// <remarks>
-        /// Defaults to 443 if not provided.
-        /// </remarks>
         public int? HttpsPort { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.HttpsPolicy/Microsoft.AspNetCore.HttpsPolicy.csproj
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/Microsoft.AspNetCore.HttpsPolicy.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Rewrite\Microsoft.AspNetCore.Rewrite.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="$(MicrosoftAspNetCoreServerKestrelCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="$(MicrosoftAspNetCoreHttpExtensionsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.HttpsPolicy/Microsoft.AspNetCore.HttpsPolicy.csproj
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/Microsoft.AspNetCore.HttpsPolicy.csproj
@@ -11,7 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="$(MicrosoftAspNetCoreServerKestrelCorePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="$(MicrosoftAspNetCoreHttpExtensionsPackageVersion)" />
-  </ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="$(MicrosoftAspNetCoreServerKestrelCorePackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftAspNetCoreHostingAbstractionsPackageVersion)" />  </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.HttpsPolicy/Microsoft.AspNetCore.HttpsPolicy.csproj
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/Microsoft.AspNetCore.HttpsPolicy.csproj
@@ -11,8 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpAbstractionsPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="$(MicrosoftAspNetCoreHttpExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftAspNetCoreHostingAbstractionsPackageVersion)" />  </ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftAspNetCoreHostingAbstractionsPackageVersion)" /> 
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.HttpsPolicy/Microsoft.AspNetCore.HttpsPolicy.csproj
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/Microsoft.AspNetCore.HttpsPolicy.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="$(MicrosoftAspNetCoreHttpExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="$(MicrosoftAspNetCoreServerKestrelCorePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftAspNetCoreHostingAbstractionsPackageVersion)" />  </ItemGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HttpsPolicyTests.cs
+++ b/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HttpsPolicyTests.cs
@@ -8,7 +8,9 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
@@ -55,7 +57,9 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
                     });
                 });
 
-            var server = new TestServer(builder);
+            var featureCollection = new FeatureCollection();
+            featureCollection.Set<IServerAddressesFeature>(new ServerAddressesFeature());
+            var server = new TestServer(builder, featureCollection);
             var client = server.CreateClient();
 
             var request = new HttpRequestMessage(HttpMethod.Get, "");

--- a/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HttpsRedirectionMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HttpsRedirectionMiddlewareTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
         [InlineData(443, "5000", "https://localhost:4444/", "https://localhost/")]
         [InlineData(4000, "5000", "https://localhost:4444/", "https://localhost:4000/")]
         [InlineData(5000, null, "https://localhost:4444/", "https://localhost:5000/")]
-        public async Task SetHttpsPortEnvironmentVariable_ReturnsCorrectStatusCodeOnResponse(int? optionsHttpsPort, string configHttpsPort, string serverAddressFeatureUrl, string expectedUrl)
+        public async Task SetHttpsPortEnvironmentVariableAndServerFeature_ReturnsCorrectStatusCodeOnResponse(int? optionsHttpsPort, string configHttpsPort, string serverAddressFeatureUrl, string expectedUrl)
         {
             var builder = new WebHostBuilder()
                .ConfigureServices(services =>

--- a/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HttpsRedirectionMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HttpsRedirectionMiddlewareTests.cs
@@ -165,7 +165,10 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
             featureCollection.Set<IServerAddressesFeature>(new ServerAddressesFeature());
 
             var server = new TestServer(builder, featureCollection);
-            server.Features.Get<IServerAddressesFeature>().Addresses.Add(serverAddressFeatureUrl);
+            if (serverAddressFeatureUrl != null)
+            {
+                server.Features.Get<IServerAddressesFeature>().Addresses.Add(serverAddressFeatureUrl);
+            }
 
             var client = server.CreateClient();
 


### PR DESCRIPTION
For #275 
Few notes:
- The middleware requires that the IServerAddressesFeature is implemented now (shouldn't be a problem, just something to note for tests)
- I needed to create a new HttpsMiddleware (rather than use Urlrewrite) as we need to inject the IServerAddressFeature and evaluate it on first request.