### PR TITLE
Increases timeout on Regex in Rewrite.

### DIFF
--- a/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/RuleBuilder.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/RuleBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
         private UrlMatch _match;
         private CookieActionFactory _cookieActionFactory = new CookieActionFactory();
 
-        private readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(1);
+        private readonly TimeSpan _regexTimeout = TimeSpan.FromSeconds(1);
 
         public ApacheModRewriteRule Build()
         {
@@ -68,11 +68,11 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
                 case ConditionType.Regex:
                     if (flags.HasFlag(FlagType.NoCase))
                     {
-                        condition.Match = new RegexMatch(new Regex(input.Operand, RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexTimeout), input.Invert);
+                        condition.Match = new RegexMatch(new Regex(input.Operand, RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase, _regexTimeout), input.Invert);
                     }
                     else
                     {
-                        condition.Match = new RegexMatch(new Regex(input.Operand, RegexOptions.CultureInvariant | RegexOptions.Compiled, RegexTimeout), input.Invert);
+                        condition.Match = new RegexMatch(new Regex(input.Operand, RegexOptions.CultureInvariant | RegexOptions.Compiled, _regexTimeout), input.Invert);
                     }
                     break;
                 case ConditionType.IntComp:
@@ -160,11 +160,11 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
         {
             if (flags.HasFlag(FlagType.NoCase))
             {
-                _match = new RegexMatch(new Regex(input.Operand, RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexTimeout), input.Invert);
+                _match = new RegexMatch(new Regex(input.Operand, RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase, _regexTimeout), input.Invert);
             }
             else
             {
-                _match = new RegexMatch(new Regex(input.Operand, RegexOptions.CultureInvariant | RegexOptions.Compiled, RegexTimeout), input.Invert);
+                _match = new RegexMatch(new Regex(input.Operand, RegexOptions.CultureInvariant | RegexOptions.Compiled, _regexTimeout), input.Invert);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UriMatchCondition.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UriMatchCondition.cs
@@ -9,12 +9,17 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 {
     public class UriMatchCondition : Condition
     {
+        private TimeSpan _regexTimeout = TimeSpan.FromSeconds(1);
+
         public UriMatchCondition(InputParser inputParser, string input, string pattern, UriMatchPart uriMatchPart, bool ignoreCase, bool negate)
         {
+            var regexOptions = RegexOptions.CultureInvariant | RegexOptions.Compiled;
+            regexOptions = ignoreCase ? regexOptions | RegexOptions.IgnoreCase : regexOptions;
             var regex = new Regex(
                 pattern,
-                ignoreCase ? RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase : RegexOptions.CultureInvariant | RegexOptions.Compiled,
-                TimeSpan.FromMilliseconds(1));
+                regexOptions,
+                _regexTimeout
+            );
             Input = inputParser.ParseInputString(input, uriMatchPart);
             Match = new RegexMatch(regex, negate);
         }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteRuleBuilder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 {
     public class UrlRewriteRuleBuilder
     {
-        private readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(1);
+        private readonly TimeSpan _regexTimeout = TimeSpan.FromSeconds(1);
 
         public string Name { get; set; }
         public bool Enabled { get; set; }
@@ -48,12 +48,12 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                     {
                         if (ignoreCase)
                         {
-                            var regex = new Regex(input, RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexTimeout);
+                            var regex = new Regex(input, RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase, _regexTimeout);
                             _initialMatch = new RegexMatch(regex, negate);
                         }
                         else
                         {
-                            var regex = new Regex(input, RegexOptions.CultureInvariant | RegexOptions.Compiled, RegexTimeout);
+                            var regex = new Regex(input, RegexOptions.CultureInvariant | RegexOptions.Compiled, _regexTimeout);
                             _initialMatch = new RegexMatch(regex, negate);
                         }
                         break;

--- a/src/Microsoft.AspNetCore.Rewrite/RewriteOptions.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/RewriteOptions.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Hosting;
-using System;
 
 namespace Microsoft.AspNetCore.Rewrite
 {

--- a/src/Microsoft.AspNetCore.Rewrite/RewriteOptions.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/RewriteOptions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Hosting;
+using System;
 
 namespace Microsoft.AspNetCore.Rewrite
 {


### PR DESCRIPTION
For #279 . This will most likely be the PR to patch back to 1.1.x and 2.0.x. For 2.1.x or 3.0.x, we may want to redesign/ do something a bit different. 

Note, the regex objects themselves are all private or created in builders themselves, so it is hard/can't be tested without exposing them.