### PR TITLE
Https Redirect: Change default status code to 307

### DIFF
--- a/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionOptions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HttpsRedirectionOptions.cs
@@ -11,9 +11,9 @@ namespace Microsoft.AspNetCore.HttpsPolicy
     public class HttpsRedirectionOptions
     {
         /// <summary>
-        /// The status code to redirect the response to.
+        /// The status code used for the redirect response. The default is 307.
         /// </summary>
-        public int RedirectStatusCode { get; set; } = StatusCodes.Status302Found;
+        public int RedirectStatusCode { get; set; } = StatusCodes.Status307TemporaryRedirect;
 
         /// <summary>
         /// The HTTPS port to be added to the redirected URL.

--- a/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HttpsRedirectionMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HttpsRedirectionMiddlewareTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
 
             var response = await client.SendAsync(request);
 
-            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            Assert.Equal(HttpStatusCode.RedirectKeepVerb, response.StatusCode);
             Assert.Equal("https://localhost/", response.Headers.Location.ToString());
         }
 


### PR DESCRIPTION
#210 
307 indicates that the method should not be changed when redirecting as was common practice for 301. This works better for request with bodies.