### PR TITLE
Reload HostFilter options on change

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -14,6 +14,7 @@
     <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview3-32110</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationExtensionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationExtensionsPackageVersion>
     <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationJsonPackageVersion>
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsLoggingAbstractionsPackageVersion>

--- a/samples/HostFilteringSample/Program.cs
+++ b/samples/HostFilteringSample/Program.cs
@@ -25,8 +25,8 @@ namespace HostFilteringSample
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
                     var env = hostingContext.HostingEnvironment;
-                    config.AddJsonFile("appsettings.json", optional: true)
-                          .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                    config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                          .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
                 })
                 .UseKestrel()
                 .UseStartup<Startup>();

--- a/samples/HostFilteringSample/Startup.cs
+++ b/samples/HostFilteringSample/Startup.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace HostFilteringSample
 {
@@ -23,9 +26,22 @@ namespace HostFilteringSample
         {
             services.AddHostFiltering(options =>
             {
-                // If this is excluded then it will fall back to the server's addresses
-                options.AllowedHosts = Config.GetSection("AllowedHosts").Get<List<string>>();
+
             });
+
+            // Fallback
+            services.PostConfigure<HostFilteringOptions>(options =>
+            {
+                if (options.AllowedHosts == null || options.AllowedHosts.Count == 0)
+                {
+                    // "AllowedHosts": "localhost;127.0.0.1;[::1]"
+                    var hosts = Config["AllowedHosts"]?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                    // Fall back to "*" to disable.
+                    options.AllowedHosts = (hosts?.Length > 0 ? hosts : new[] { "*" });
+                }
+            });
+            // Change notification
+            services.AddSingleton<IOptionsChangeTokenSource<HostFilteringOptions>>(new ConfigurationChangeTokenSource<HostFilteringOptions>(Config));
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)

--- a/samples/HostFilteringSample/appsettings.Development.json
+++ b/samples/HostFilteringSample/appsettings.Development.json
@@ -1,3 +1,3 @@
 ﻿{
-  "AllowedHosts": [ "localhost", "127.0.0.1", "[::1]" ]
+  "AllowedHosts": "localhost;127.0.0.1;[::1]"
 }

--- a/samples/HostFilteringSample/appsettings.Production.json
+++ b/samples/HostFilteringSample/appsettings.Production.json
@@ -1,3 +1,3 @@
 ﻿{
-  "AllowedHosts": [ "example.com", "localhost" ]
+  "AllowedHosts": "example.com;localhost"
 }

--- a/test/Microsoft.AspNetCore.HostFiltering.Tests/Microsoft.AspNetCore.HostFiltering.Tests.csproj
+++ b/test/Microsoft.AspNetCore.HostFiltering.Tests/Microsoft.AspNetCore.HostFiltering.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.HostFiltering\Microsoft.AspNetCore.HostFiltering.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsConfigurationExtensionsPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 #317 @DamianEdwards requested this magic.

As follow up, the code from the sample Startup will be used to update CreateDefaultBuilder:
https://github.com/aspnet/MetaPackages/blob/f972d15501fa494e39ffc81ef3a594b64780ca4a/src/Microsoft.AspNetCore/WebHost.cs#L187-L191