### PR TITLE
Add logging to HstsMiddleware

### DIFF
--- a/src/Microsoft.AspNetCore.HttpsPolicy/HstsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HstsMiddleware.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpsPolicy.Internal;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -24,13 +26,15 @@ namespace Microsoft.AspNetCore.HttpsPolicy
         private readonly RequestDelegate _next;
         private readonly StringValues _strictTransportSecurityValue;
         private readonly IList<string> _excludedHosts;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Initialize the HSTS middleware.
         /// </summary>
         /// <param name="next"></param>
         /// <param name="options"></param>
-        public HstsMiddleware(RequestDelegate next, IOptions<HstsOptions> options)
+        /// <param name="loggerFactory"></param>
+        public HstsMiddleware(RequestDelegate next, IOptions<HstsOptions> options, ILoggerFactory loggerFactory)
         {
             if (options == null)
             {
@@ -46,6 +50,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             var preload = hstsOptions.Preload ? Preload : StringSegment.Empty;
             _strictTransportSecurityValue = new StringValues($"max-age={maxAge}{includeSubdomains}{preload}");
             _excludedHosts = hstsOptions.ExcludedHosts;
+            _logger = loggerFactory.CreateLogger<HstsMiddleware>();
         }
 
         /// <summary>
@@ -55,10 +60,20 @@ namespace Microsoft.AspNetCore.HttpsPolicy
         /// <returns></returns>
         public Task Invoke(HttpContext context)
         {
-            if (context.Request.IsHttps && !IsHostExcluded(context.Request.Host.Host))
+            if (!context.Request.IsHttps)
             {
-                context.Response.Headers[HeaderNames.StrictTransportSecurity] = _strictTransportSecurityValue;
+                _logger.SkippingInsecure();
+                return _next(context);
             }
+
+            if (IsHostExcluded(context.Request.Host.Host))
+            {
+                _logger.SkippingExcludedHost(context.Request.Host.Host);
+                return _next(context);
+            }
+
+            context.Response.Headers[HeaderNames.StrictTransportSecurity] = _strictTransportSecurityValue;
+            _logger.AddingHstsHeader();
 
             return _next(context);
         }

--- a/src/Microsoft.AspNetCore.HttpsPolicy/internal/HstsLoggingExtensions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/internal/HstsLoggingExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.HttpsPolicy.Internal
+{
+    internal static class HstsLoggingExtensions
+    {
+        private static readonly Action<ILogger, Exception> _notSecure;
+        private static readonly Action<ILogger, string, Exception> _excludedHost;
+        private static readonly Action<ILogger, Exception> _addingHstsHeader;
+
+        static HstsLoggingExtensions()
+        {
+            _notSecure = LoggerMessage.Define(LogLevel.Debug, 1, "The request is insecure. Skipping HSTS header.");
+            _excludedHost = LoggerMessage.Define<string>(LogLevel.Debug, 2, "The host '{host}' is excluded. Skipping HSTS header.");
+            _addingHstsHeader = LoggerMessage.Define(LogLevel.Trace, 3, "Adding HSTS header to response.");
+        }
+
+        public static void SkippingInsecure(this ILogger logger)
+        {
+            _notSecure(logger, null);
+        }
+
+        public static void SkippingExcludedHost(this ILogger logger, string host)
+        {
+            _excludedHost(logger, host, null);
+        }
+
+        public static void AddingHstsHeader(this ILogger logger)
+        {
+            _addingHstsHeader(logger, null);
+        }
+    }
+}


### PR DESCRIPTION
Added logging to HstsMiddleware in the style of HttpsRedirectionMiddleware.
- Debug log when HSTS is skipped because the request is insecure
- Debug log when HSTS is skipped because the host is excluded (by default or otherwise)
- Trace log when HSTS is added to the response.

Addresses part of #278