### PR TITLE
Add back Hsts constructor 

### DIFF
--- a/src/Microsoft.AspNetCore.HttpsPolicy/HstsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HstsMiddleware.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpsPolicy.Internal;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -52,6 +53,14 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             _excludedHosts = hstsOptions.ExcludedHosts;
             _logger = loggerFactory.CreateLogger<HstsMiddleware>();
         }
+
+        /// <summary>
+        /// Initialize the HSTS middleware.
+        /// </summary>
+        /// <param name="next"></param>
+        /// <param name="options"></param>
+        public HstsMiddleware(RequestDelegate next, IOptions<HstsOptions> options)
+            : this(next, options, NullLoggerFactory.Instance) { }
 
         /// <summary>
         /// Invoke the middleware.

--- a/src/Microsoft.AspNetCore.HttpsPolicy/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/breakingchanges.netcore.json
@@ -1,7 +1,0 @@
-[
-    {
-        "TypeId": "public class Microsoft.AspNetCore.HttpsPolicy.HstsMiddleware",
-        "MemberId": "public .ctor(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.HttpsPolicy.HstsOptions> options)",
-        "Kind": "Removal"
-    }
-]


### PR DESCRIPTION
#339 This mitigates a binary breaking change, but we don't expect anyone to actually call this overload.