### PR TITLE
Add Brotli compression provider

### DIFF
--- a/BasicMiddleware.sln
+++ b/BasicMiddleware.sln
@@ -76,6 +76,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.HostFi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.HostFiltering", "src\Microsoft.AspNetCore.HostFiltering\Microsoft.AspNetCore.HostFiltering.csproj", "{762F7276-C916-4111-A6C0-41668ABB3823}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{C6DA6317-30FC-42FE-891C-64E75D88FF12}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.ResponseCompression.Benchmarks", "benchmarks\Microsoft.AspNetCore.ResponseCompression.Benchmarks\Microsoft.AspNetCore.ResponseCompression.Benchmarks.csproj", "{5AF10E85-5076-40B9-84CF-9830B585ABE5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -154,6 +158,10 @@ Global
 		{762F7276-C916-4111-A6C0-41668ABB3823}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{762F7276-C916-4111-A6C0-41668ABB3823}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{762F7276-C916-4111-A6C0-41668ABB3823}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AF10E85-5076-40B9-84CF-9830B585ABE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AF10E85-5076-40B9-84CF-9830B585ABE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AF10E85-5076-40B9-84CF-9830B585ABE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AF10E85-5076-40B9-84CF-9830B585ABE5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -178,6 +186,7 @@ Global
 		{5CEA6F31-A829-4A02-8CD5-EC3DDD4CC1EA} = {59A9B64C-E9BE-409E-89A2-58D72E2918F5}
 		{4BC947ED-13B8-4BE6-82A4-96A48D86980B} = {8437B0F3-3894-4828-A945-A9187F37631D}
 		{762F7276-C916-4111-A6C0-41668ABB3823} = {A5076D28-FA7E-4606-9410-FEDD0D603527}
+		{5AF10E85-5076-40B9-84CF-9830B585ABE5} = {C6DA6317-30FC-42FE-891C-64E75D88FF12}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4518E9CE-3680-4E05-9259-B64EA7807158}

--- a/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/AssemblyInfo.cs
+++ b/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/AssemblyInfo.cs
@@ -1,1 +1,4 @@
-﻿[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/AssemblyInfo.cs
+++ b/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks.csproj
+++ b/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.ResponseCompression\Microsoft.AspNetCore.ResponseCompression.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="$(MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/ResponseCompressionProviderBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/ResponseCompressionProviderBenchmark.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.ResponseCompression.Benchmarks
+{
+    public class ResponseCompressionProviderBenchmark
+    {
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var services = new ServiceCollection()
+                .AddOptions()
+                .AddResponseCompression()
+                .BuildServiceProvider();
+
+            var options = new ResponseCompressionOptions();
+
+            Provider = new ResponseCompressionProvider(services, Options.Create(options));
+        }
+
+        [ParamsSource(nameof(EncodingStrings))]
+        public string AcceptEncoding { get; set; }
+
+        public static IEnumerable<string> EncodingStrings()
+        {
+            return new[]
+            {
+                "gzip;q=0.8, compress;q=0.6, br;q=0.4",
+                "gzip, compress, br",
+                "br, compress, gzip",
+                "gzip, compress",
+                "identity",
+                "*"
+            };
+        }
+
+        public ResponseCompressionProvider Provider { get; set; }
+
+        [Benchmark]
+        public ICompressionProvider GetCompressionProvider()
+        {
+            var context = new DefaultHttpContext();
+
+            context.Request.Headers[HeaderNames.AcceptEncoding] = AcceptEncoding;
+
+            return Provider.GetCompressionProvider(context);
+        }
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/ResponseCompressionProviderBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.ResponseCompression.Benchmarks/ResponseCompressionProviderBenchmark.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,9 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
+    <BenchmarkDotNetPackageVersion>0.10.14</BenchmarkDotNetPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.2.0-preview1-17099</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.2.0-preview1-34640</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
     <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.2.0-preview1-34640</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.2.0-preview1-34640</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
     <MicrosoftAspNetCoreHttpExtensionsPackageVersion>2.2.0-preview1-34640</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
@@ -15,6 +17,7 @@
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.2.0-preview1-34640</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationBinderPackageVersion>2.2.0-preview1-34640</MicrosoftExtensionsConfigurationBinderPackageVersion>
     <MicrosoftExtensionsConfigurationJsonPackageVersion>2.2.0-preview1-34640</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.2.0-preview1-34640</MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.2.0-preview1-34640</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.2.0-preview1-34640</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>2.2.0-preview1-34640</MicrosoftExtensionsLoggingConsolePackageVersion>

--- a/src/Microsoft.AspNetCore.ResponseCompression/BrotliCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/BrotliCompressionProvider.cs
@@ -9,15 +9,15 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.AspNetCore.ResponseCompression
 {
     /// <summary>
-    /// GZIP compression provider.
+    /// Brotli compression provider.
     /// </summary>
-    public class GzipCompressionProvider : ICompressionProvider
+    public class BrotliCompressionProvider : ICompressionProvider
     {
         /// <summary>
-        /// Creates a new instance of GzipCompressionProvider with options.
+        /// Creates a new instance of <see cref="BrotliCompressionProvider"/> with options.
         /// </summary>
         /// <param name="options"></param>
-        public GzipCompressionProvider(IOptions<GzipCompressionProviderOptions> options)
+        public BrotliCompressionProvider(IOptions<BrotliCompressionProviderOptions> options)
         {
             if (options == null)
             {
@@ -27,30 +27,24 @@ namespace Microsoft.AspNetCore.ResponseCompression
             Options = options.Value;
         }
 
-        private GzipCompressionProviderOptions Options { get; }
+        private BrotliCompressionProviderOptions Options { get; }
 
         /// <inheritdoc />
-        public string EncodingName => "gzip";
+        public string EncodingName => "br";
 
         /// <inheritdoc />
-        public bool SupportsFlush
-        {
-            get
-            {
-#if NET461
-                return false;
-#elif NETSTANDARD2_0 || NETCOREAPP2_1
-                return true;
-#else
-#error target frameworks need to be updated
-#endif
-            }
-        }
+        public bool SupportsFlush => true;
 
         /// <inheritdoc />
         public Stream CreateStream(Stream outputStream)
         {
-            return new GZipStream(outputStream, Options.Level, leaveOpen: true);
+#if NETCOREAPP2_1
+            return new BrotliStream(outputStream, Options.Level, leaveOpen: true);
+#elif NET461 || NETSTANDARD2_0
+            throw new PlatformNotSupportedException();
+#else
+#error Target frameworks need to be updated.
+#endif
         }
     }
 }

--- a/src/Microsoft.AspNetCore.ResponseCompression/BrotliCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/BrotliCompressionProvider.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
 #if NETCOREAPP2_1
             return new BrotliStream(outputStream, Options.Level, leaveOpen: true);
 #elif NET461 || NETSTANDARD2_0
+            // Brotli is only supported in .NET Core 2.1+
             throw new PlatformNotSupportedException();
 #else
 #error Target frameworks need to be updated.

--- a/src/Microsoft.AspNetCore.ResponseCompression/BrotliCompressionProviderOptions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/BrotliCompressionProviderOptions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO.Compression;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.ResponseCompression
+{
+    /// <summary>
+    /// Options for the <see cref="BrotliCompressionProvider"/>
+    /// </summary>
+    public class BrotliCompressionProviderOptions : IOptions<BrotliCompressionProviderOptions>
+    {
+        /// <summary>
+        /// What level of compression to use for the stream. The default is <see cref="CompressionLevel.Fastest"/>.
+        /// </summary>
+        public CompressionLevel Level { get; set; } = CompressionLevel.Fastest;
+
+        /// <inheritdoc />
+        BrotliCompressionProviderOptions IOptions<BrotliCompressionProviderOptions>.Value => this;
+    }
+}

--- a/src/Microsoft.AspNetCore.ResponseCompression/Microsoft.AspNetCore.ResponseCompression.csproj
+++ b/src/Microsoft.AspNetCore.ResponseCompression/Microsoft.AspNetCore.ResponseCompression.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core middleware for HTTP Response compression.</Description>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionOptions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionOptions.cs
@@ -22,7 +22,8 @@ namespace Microsoft.AspNetCore.ResponseCompression
         public bool EnableForHttps { get; set; } = false;
 
         /// <summary>
-        /// The ICompressionProviders to use for responses.
+        /// The <see cref="ICompressionProvider"/> types to use for responses.
+        /// Providers are prioritized based on the order they are added.
         /// </summary>
         public CompressionProviderCollection Providers { get; } = new CompressionProviderCollection();
     }

--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
@@ -38,7 +38,17 @@ namespace Microsoft.AspNetCore.ResponseCompression
             if (_providers.Length == 0)
             {
                 // Use the factory so it can resolve IOptions<GzipCompressionProviderOptions> from DI.
-                _providers = new ICompressionProvider[] { new CompressionProviderFactory(typeof(GzipCompressionProvider)) };
+                _providers = new ICompressionProvider[]
+                {
+                    new CompressionProviderFactory(typeof(GzipCompressionProvider)),
+#if NETCOREAPP2_1
+                    new CompressionProviderFactory(typeof(BrotliCompressionProvider))
+#elif NET461 || NETSTANDARD2_0
+                    // Brotli is only supported in .NET Core 2.1+
+#else
+#error Target frameworks need to be updated.
+#endif
+                };
             }
             for (var i = 0; i < _providers.Length; i++)
             {

--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
@@ -40,14 +40,14 @@ namespace Microsoft.AspNetCore.ResponseCompression
                 // Use the factory so it can resolve IOptions<GzipCompressionProviderOptions> from DI.
                 _providers = new ICompressionProvider[]
                 {
-                    new CompressionProviderFactory(typeof(GzipCompressionProvider)),
 #if NETCOREAPP2_1
-                    new CompressionProviderFactory(typeof(BrotliCompressionProvider))
+                    new CompressionProviderFactory(typeof(BrotliCompressionProvider)),
 #elif NET461 || NETSTANDARD2_0
                     // Brotli is only supported in .NET Core 2.1+
 #else
 #error Target frameworks need to be updated.
 #endif
+                    new CompressionProviderFactory(typeof(GzipCompressionProvider)),
                 };
             }
             for (var i = 0; i < _providers.Length; i++)

--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
                     var encodingName = encoding.Value;
                     var quality = encoding.Quality.GetValueOrDefault(1);
 
-                    if (Math.Abs(quality) < double.Epsilon)
+                    if (quality < double.Epsilon)
                     {
                         continue;
                     }
@@ -129,19 +129,14 @@ namespace Microsoft.AspNetCore.ResponseCompression
                     }
                 }
 
-                if (candidates.Count == 0)
+                if (candidates.Count <= 1)
                 {
-                    return null;
-                }
-
-                if (candidates.Count == 1)
-                {
-                    return candidates.ElementAt(0).Provider;
+                    return candidates.ElementAtOrDefault(0).Provider;
                 }
 
                 var accepted = candidates
                     .OrderByDescending(x => x.Quality)
-                    .ThenBy(x => x.Order)
+                    .ThenBy(x => x.Priority)
                     .First();
 
                 return accepted.Provider;
@@ -189,11 +184,11 @@ namespace Microsoft.AspNetCore.ResponseCompression
 
         private readonly struct ProviderCandidate : IEquatable<ProviderCandidate>
         {
-            public ProviderCandidate(string encodingName, double quality, int order, ICompressionProvider provider)
+            public ProviderCandidate(string encodingName, double quality, int priority, ICompressionProvider provider)
             {
                 EncodingName = encodingName;
                 Quality = quality;
-                Order = order;
+                Priority = priority;
                 Provider = provider;
             }
 
@@ -201,7 +196,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
 
             public double Quality { get; }
 
-            public int Order { get; }
+            public int Priority { get; }
 
             public ICompressionProvider Provider { get; }
 

--- a/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCompression/ResponseCompressionProvider.cs
@@ -125,7 +125,9 @@ namespace Microsoft.AspNetCore.ResponseCompression
 
                     if (StringSegment.Equals("identity", encodingName, StringComparison.OrdinalIgnoreCase))
                     {
-                        candidates.Add(new ProviderCandidate(encodingName.Value, quality, int.MaxValue, null));
+                        // We add 'identity' to the list of "candidates" with a very low priority and no provider.
+                        // This will allow it to be ordered based on its quality (and priority) later in the method.
+                        candidates.Add(new ProviderCandidate(encodingName.Value, quality, priority: int.MaxValue, provider: null));
                     }
                 }
 

--- a/test/Microsoft.AspNetCore.ResponseCompression.Tests/ResponseCompressionMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.ResponseCompression.Tests/ResponseCompressionMiddlewareTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [Fact]
         public async Task Request_AcceptGzipDeflate_CompressedGzip()
         {
-            var response = await InvokeMiddleware(100, requestAcceptEncodings: new string[] { "gzip", "deflate" }, responseType: TextPlain);
+            var response = await InvokeMiddleware(100, requestAcceptEncodings: new[] { "gzip", "deflate" }, responseType: TextPlain);
 
             CheckResponseCompressed(response, expectedBodyLength: 24, expectedEncoding: "gzip");
         }
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [Fact]
         public async Task Request_AcceptBrotli_CompressedBrotli()
         {
-            var response = await InvokeMiddleware(100, requestAcceptEncodings: new string[] { "br" }, responseType: TextPlain);
+            var response = await InvokeMiddleware(100, requestAcceptEncodings: new[] { "br" }, responseType: TextPlain);
 
 #if NET461
             CheckResponseNotCompressed(response, expectedBodyLength: 100, sendVaryHeader: true);
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [InlineData("br", "gzip")]
         public async Task Request_AcceptMixed_CompressedGzip(string encoding1, string encoding2)
         {
-            var response = await InvokeMiddleware(100, new string[] { encoding1, encoding2 }, responseType: TextPlain);
+            var response = await InvokeMiddleware(100, new[] { encoding1, encoding2 }, responseType: TextPlain);
 
             CheckResponseCompressed(response, expectedBodyLength: 24, expectedEncoding: "gzip");
         }
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [Fact]
         public async Task Request_AcceptUnknown_NotCompressed()
         {
-            var response = await InvokeMiddleware(100, requestAcceptEncodings: new string[] { "unknown" }, responseType: TextPlain);
+            var response = await InvokeMiddleware(100, requestAcceptEncodings: new[] { "unknown" }, responseType: TextPlain);
 
             CheckResponseNotCompressed(response, expectedBodyLength: 100, sendVaryHeader: true);
         }
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [Fact]
         public async Task Request_AcceptStar_Compressed()
         {
-            var response = await InvokeMiddleware(100, requestAcceptEncodings: new string[] { "*" }, responseType: TextPlain);
+            var response = await InvokeMiddleware(100, requestAcceptEncodings: new[] { "*" }, responseType: TextPlain);
 
             CheckResponseCompressed(response, expectedBodyLength: 24, expectedEncoding: "gzip");
         }
@@ -244,15 +244,15 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [Fact]
         public async Task Request_AcceptIdentity_NotCompressed()
         {
-            var response = await InvokeMiddleware(100, requestAcceptEncodings: new string[] { "identity" }, responseType: TextPlain);
+            var response = await InvokeMiddleware(100, requestAcceptEncodings: new[] { "identity" }, responseType: TextPlain);
 
             CheckResponseNotCompressed(response, expectedBodyLength: 100, sendVaryHeader: true);
         }
 
         [Theory]
-        [InlineData(new string[] { "identity;q=0.5", "gzip;q=1" }, 24)]
-        [InlineData(new string[] { "identity;q=0", "gzip;q=0.8" }, 24)]
-        [InlineData(new string[] { "identity;q=0.5", "gzip" }, 24)]
+        [InlineData(new[] { "identity;q=0.5", "gzip;q=1" }, 24)]
+        [InlineData(new[] { "identity;q=0", "gzip;q=0.8" }, 24)]
+        [InlineData(new[] { "identity;q=0.5", "gzip" }, 24)]
         public async Task Request_AcceptWithHigherCompressionQuality_Compressed(string[] acceptEncodings, int expectedBodyLength)
         {
             var response = await InvokeMiddleware(100, requestAcceptEncodings: acceptEncodings, responseType: TextPlain);
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { "gzip;q=0.5", "identity;q=0.8" }, 100)]
+        [InlineData(new[] { "gzip;q=0.5", "identity;q=0.8" }, 100)]
         public async Task Request_AcceptWithhigherIdentityQuality_NotCompressed(string[] acceptEncodings, int expectedBodyLength)
         {
             var response = await InvokeMiddleware(100, requestAcceptEncodings: acceptEncodings, responseType: TextPlain);
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [Fact]
         public async Task Response_UnknownMimeType_NotCompressed()
         {
-            var response = await InvokeMiddleware(100, requestAcceptEncodings: new string[] { "gzip" }, responseType: "text/custom");
+            var response = await InvokeMiddleware(100, requestAcceptEncodings: new[] { "gzip" }, responseType: "text/custom");
 
             CheckResponseNotCompressed(response, expectedBodyLength: 100, sendVaryHeader: false);
         }
@@ -280,7 +280,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [Fact]
         public async Task Response_WithContentRange_NotCompressed()
         {
-            var response = await InvokeMiddleware(50, requestAcceptEncodings: new string[] { "gzip" }, responseType: TextPlain, addResponseAction: (r) =>
+            var response = await InvokeMiddleware(50, requestAcceptEncodings: new[] { "gzip" }, responseType: TextPlain, addResponseAction: (r) =>
             {
                 r.Headers[HeaderNames.ContentRange] = "1-2/*";
             });
@@ -293,7 +293,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         {
             var otherContentEncoding = "something";
 
-            var response = await InvokeMiddleware(50, requestAcceptEncodings: new string[] { "gzip" }, responseType: TextPlain, addResponseAction: (r) =>
+            var response = await InvokeMiddleware(50, requestAcceptEncodings: new[] { "gzip" }, responseType: TextPlain, addResponseAction: (r) =>
             {
                 r.Headers[HeaderNames.ContentEncoding] = otherContentEncoding;
             });
@@ -327,8 +327,11 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
                     });
                 });
 
-            var server = new TestServer(builder);
-            server.BaseAddress = new Uri("https://localhost/");
+            var server = new TestServer(builder)
+            {
+                BaseAddress = new Uri("https://localhost/")
+            };
+
             var client = server.CreateClient();
 
             var request = new HttpRequestMessage(HttpMethod.Get, "");
@@ -449,8 +452,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
 
             var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
-            IEnumerable<string> contentMD5 = null;
-            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out contentMD5));
+            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out _));
             Assert.Single(response.Content.Headers.ContentEncoding, encoding);
 
             var body = await response.Content.ReadAsStreamAsync();
@@ -496,8 +498,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
 
             var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
-            IEnumerable<string> contentMD5 = null;
-            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out contentMD5));
+            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out _));
             Assert.Single(response.Content.Headers.ContentEncoding, encoding);
 
             var body = await response.Content.ReadAsStreamAsync();
@@ -559,8 +560,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
             Assert.NotNull(response.Content.Headers.GetValues(HeaderNames.ContentMD5));
             Assert.Empty(response.Content.Headers.ContentEncoding);
 #elif NETCOREAPP2_2 // Flush supported, compression enabled
-            IEnumerable<string> contentMD5 = null;
-            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out contentMD5));
+            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out _));
             Assert.Single(response.Content.Headers.ContentEncoding, encoding);
 #else
 #error Target frameworks need to be updated.
@@ -625,8 +625,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
             Assert.NotNull(response.Content.Headers.GetValues(HeaderNames.ContentMD5));
             Assert.Empty(response.Content.Headers.ContentEncoding);
 #elif NETCOREAPP2_2 // Flush supported, compression enabled
-            IEnumerable<string> contentMD5 = null;
-            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out contentMD5));
+            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out _));
             Assert.Single(response.Content.Headers.ContentEncoding, encoding);
 #else
 #error Target framework needs to be updated
@@ -820,10 +819,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
                         context.Response.Headers[HeaderNames.ContentMD5] = "MD5";
                         context.Response.ContentType = responseType;
                         Assert.Null(context.Features.Get<IHttpSendFileFeature>());
-                        if (addResponseAction != null)
-                        {
-                            addResponseAction(context.Response);
-                        }
+                        addResponseAction?.Invoke(context.Response);
                         return context.Response.WriteAsync(new string('a', uncompressedBodyLength));
                     });
                 });
@@ -842,8 +838,6 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
 
         private void CheckResponseCompressed(HttpResponseMessage response, int expectedBodyLength, string expectedEncoding)
         {
-            IEnumerable<string> contentMD5 = null;
-
             var containsVaryAcceptEncoding = false;
             foreach (var value in response.Headers.GetValues(HeaderNames.Vary))
             {
@@ -854,7 +848,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
                 }
             }
             Assert.True(containsVaryAcceptEncoding);
-            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out contentMD5));
+            Assert.False(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out _));
             Assert.Single(response.Content.Headers.ContentEncoding, expectedEncoding);
             Assert.Equal(expectedBodyLength, response.Content.Headers.ContentLength);
         }

--- a/test/Microsoft.AspNetCore.ResponseCompression.Tests/ResponseCompressionMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.ResponseCompression.Tests/ResponseCompressionMiddlewareTest.cs
@@ -82,6 +82,16 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
 #endif
         }
 
+        [Theory]
+        [InlineData("gzip", "br")]
+        [InlineData("br", "gzip")]
+        public async Task Request_AcceptMixed_CompressedGzip(string encoding1, string encoding2)
+        {
+            var response = await InvokeMiddleware(100, new string[] { encoding1, encoding2 }, responseType: TextPlain);
+
+            CheckResponseCompressed(response, expectedBodyLength: 24, expectedEncoding: "gzip");
+        }
+
         [Fact]
         public async Task Request_AcceptUnknown_NotCompressed()
         {

--- a/test/Microsoft.AspNetCore.ResponseCompression.Tests/ResponseCompressionMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.ResponseCompression.Tests/ResponseCompressionMiddlewareTest.cs
@@ -85,28 +85,34 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         [Theory]
         [InlineData("gzip", "br")]
         [InlineData("br", "gzip")]
-        public async Task Request_AcceptMixed_CompressedGzip(string encoding1, string encoding2)
+        public async Task Request_AcceptMixed_CompressedBrotli(string encoding1, string encoding2)
         {
             var response = await InvokeMiddleware(100, new[] { encoding1, encoding2 }, responseType: TextPlain);
 
+#if NET461
             CheckResponseCompressed(response, expectedBodyLength: 24, expectedEncoding: "gzip");
+#elif NETCOREAPP2_2
+            CheckResponseCompressed(response, expectedBodyLength: 20, expectedEncoding: "br");
+#else
+#error Target frameworks need to be updated.
+#endif
         }
 
 #if NETCOREAPP2_2
         [Theory]
         [InlineData("gzip", "br")]
         [InlineData("br", "gzip")]
-        public async Task Request_AcceptMixed_ConfiguredOrder_CompressedBrotli(string encoding1, string encoding2)
+        public async Task Request_AcceptMixed_ConfiguredOrder_CompressedGzip(string encoding1, string encoding2)
         {
             void Configure(ResponseCompressionOptions options)
             {
-                options.Providers.Add<BrotliCompressionProvider>();
                 options.Providers.Add<GzipCompressionProvider>();
+                options.Providers.Add<BrotliCompressionProvider>();
             }
 
             var response = await InvokeMiddleware(100, new[] { encoding1, encoding2 }, responseType: TextPlain, configure: Configure);
 
-            CheckResponseCompressed(response, expectedBodyLength: 20, expectedEncoding: "br");
+            CheckResponseCompressed(response, expectedBodyLength: 24, expectedEncoding: "gzip");
         }
 #elif NET461
 #else
@@ -259,7 +265,13 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
         {
             var response = await InvokeMiddleware(100, requestAcceptEncodings: new[] { "*" }, responseType: TextPlain);
 
+#if NET461
             CheckResponseCompressed(response, expectedBodyLength: 24, expectedEncoding: "gzip");
+#elif NETCOREAPP2_2
+            CheckResponseCompressed(response, expectedBodyLength: 20, expectedEncoding: "br");
+#else
+#error Target frameworks need to be updated.
+#endif
         }
 
         [Fact]


### PR DESCRIPTION
Probably needs a few more tests, like for ordering. Should the Brotli provider be added by default?

Closes https://github.com/aspnet/BasicMiddleware/issues/217