### PR TITLE
HSTS default max-age parameter update

### DIFF
--- a/src/Microsoft.AspNetCore.HttpsPolicy/HstsOptions.cs
+++ b/src/Microsoft.AspNetCore.HttpsPolicy/HstsOptions.cs
@@ -15,10 +15,10 @@ namespace Microsoft.AspNetCore.HttpsPolicy
         /// Sets the max-age parameter of the Strict-Transport-Security header.
         /// </summary>
         /// <remarks>
-        /// Max-age is required; defaults to 30 days.
+        /// Max-age is required; defaults to 1 year.
         /// See: https://tools.ietf.org/html/rfc6797#section-6.1.1
         /// </remarks>
-        public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(30);
+        public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(365);
 
         /// <summary>
         /// Enables includeSubDomain parameter of the Strict-Transport-Security header.

--- a/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HstsMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.HttpsPolicy.Tests/HstsMiddlewareTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy.Tests
             var response = await client.SendAsync(request);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("max-age=2592000", response.Headers.GetValues(HeaderNames.StrictTransportSecurity).FirstOrDefault());
+            Assert.Equal("max-age=31536000", response.Headers.GetValues(HeaderNames.StrictTransportSecurity).FirstOrDefault());
         }
 
         [Theory]


### PR DESCRIPTION
Updating default max-age parameter of the Strict-Transport-Security header to 1 year.

1 year is the industry standard. IETF is using 1 year in the sample (https://tools.ietf.org/html/rfc6797#section-6.1.1) and sonarwhal is throwing an error if it is shorter than 18 weeks (https://sonarwhal.com/docs/user-guide/rules/rule-strict-transport-security/#what-does-the-rule-check).