### PR TITLE
Handle IPv4ToIPv6 Mapped Addresses when checking known proxies/networks

### DIFF
--- a/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersMiddleware.cs
@@ -351,7 +351,11 @@ namespace Microsoft.AspNetCore.HttpOverrides
         {
             if (address.IsIPv4MappedToIPv6)
             {
-                address = address.MapToIPv4();
+                var ipv4Address = address.MapToIPv4();
+                if (CheckKnownAddress(ipv4Address))
+                {
+                    return true;
+                }
             }
             if (_options.KnownProxies.Contains(address))
             {

--- a/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersMiddleware.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/ForwardedHeadersMiddleware.cs
@@ -349,6 +349,10 @@ namespace Microsoft.AspNetCore.HttpOverrides
 
         private bool CheckKnownAddress(IPAddress address)
         {
+            if (address.IsIPv4MappedToIPv6)
+            {
+                address = address.MapToIPv4();
+            }
             if (_options.KnownProxies.Contains(address))
             {
                 return true;


### PR DESCRIPTION
Un-Map IPv4-to-IPv6-Mapped ips before comparing to known proxies/networks.

Addresses #358