### PR TITLE
Specify culture to int.TryParse

### DIFF
--- a/src/Microsoft.AspNetCore.HttpOverrides/Internal/IPEndPointParser.cs
+++ b/src/Microsoft.AspNetCore.HttpOverrides/Internal/IPEndPointParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Globalization;
 using System.Net;
 
 namespace Microsoft.AspNetCore.HttpOverrides.Internal
@@ -62,7 +63,7 @@ namespace Microsoft.AspNetCore.HttpOverrides.Internal
                 if (portPart != null)
                 {
                     int port;
-                    if (int.TryParse(portPart, out port))
+                    if (int.TryParse(portPart, NumberStyles.None, CultureInfo.InvariantCulture, out port))
                     {
                         endpoint = new IPEndPoint(address, port);
                         return true;

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/ConditionPatternParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/ApacheModRewrite/ConditionPatternParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
 {
@@ -216,7 +217,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.ApacheModRewrite
             {
                 // If the type is an integer, verify operand is actually an int
                 int res;
-                if (!int.TryParse(results.Operand, out res))
+                if (!int.TryParse(results.Operand, NumberStyles.None, CultureInfo.InvariantCulture, out res))
                 {
                     return false;
                 }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/InputParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/InputParser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.AspNetCore.Rewrite.Internal.PatternSegments;
 
 namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
@@ -181,7 +182,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
 
             var res = context.Capture();
             int index;
-            if (!int.TryParse(res, out index))
+            if (!int.TryParse(res, NumberStyles.None, CultureInfo.InvariantCulture, out index))
             {
                 throw new FormatException(Resources.FormatError_InputParserInvalidInteger(res, context.Index));
             }

--- a/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
+++ b/src/Microsoft.AspNetCore.Rewrite/Internal/IISUrlRewrite/UrlRewriteFileParser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -219,7 +220,7 @@ namespace Microsoft.AspNetCore.Rewrite.Internal.IISUrlRewrite
                     break;
                 case ActionType.CustomResponse:
                     int statusCode;
-                    if (!int.TryParse(urlAction.Attribute(RewriteTags.StatusCode)?.Value, out statusCode))
+                    if (!int.TryParse(urlAction.Attribute(RewriteTags.StatusCode)?.Value, NumberStyles.None, CultureInfo.InvariantCulture, out statusCode))
                     {
                         throw new InvalidUrlRewriteFormatException(urlAction, "A valid status code is required");
                     }


### PR DESCRIPTION
There's guidance to always specify the culture when parsing numbers, otherwise the data may be misinterpreted on some machines depending on the local culture. #356 called this to our attention and these changes should mitigate it. Note there's a deeper corefx issue there that I do not have a repro for and I'll move that to corefx after merging this.